### PR TITLE
Update Renovate package matching to use globs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
   "packageRules": [
     {
       "matchPackageNames": [
-        "^@actual-app/"
+        "@actual-app/**"
       ],
       "matchUpdateTypes": [
         "minor",
@@ -27,7 +27,7 @@
     },
     {
       "matchPackageNames": [
-        "^@actual-app/"
+        "@actual-app/**"
       ],
       "matchUpdateTypes": [
         "major"
@@ -40,7 +40,7 @@
     },
     {
       "matchPackageNames": [
-        "^(?!@actual-app/).*"
+        "!@actual-app/**"
       ],
       "matchUpdateTypes": [
         "minor",
@@ -54,7 +54,7 @@
     },
     {
       "matchPackageNames": [
-        "^(?!@actual-app/).*"
+        "!@actual-app/**"
       ],
       "matchUpdateTypes": [
         "major"


### PR DESCRIPTION
The regex was not applying correctly and thus not applying the package rules grouping and schedules. Changing to supported globs for simplicity. 