### PR TITLE
fix: sync account balances to server after bank sync

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,7 @@ import {
   runBankSync,
   downloadBudget,
   loadBudget,
+  sync as syncBudget,
 } from "@actual-app/api";
 import cronstrue from "cronstrue";
 
@@ -24,6 +25,9 @@ export async function syncAllAccounts() {
     logger.info("Syncing all accounts...");
     await runBankSync();
     logger.info("All accounts synced.");
+    logger.info("Syncing budget to server...");
+    await syncBudget();
+    logger.info("Budget synced to server successfully.");
   } catch (err) {
     logger.error({ err }, "Error syncing all accounts");
   }


### PR DESCRIPTION
After runBankSync() completes, the balance data is stored locally but not pushed to the server. This causes "Last Balance from Bank" to not update during automated syncs, only appearing after manual UI syncs.

This fix calls sync() from @actual-app/api after runBankSync() to push the balance updates to the server, ensuring automated syncs update the balance field correctly.

Closes #60

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures automated bank syncs propagate balance updates to the server.
> 
> - In `utils.ts`, after `runBankSync()` invoke `@actual-app/api`'s `sync` (aliased `syncBudget`) with new info logs
> - Update tests in `__tests__/utils.test.ts` to mock `sync`, assert success path and error handling for both bank and budget sync
> - Minor logging additions around the new sync step
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c28608019acfbcccf0e4b04338a8e7589362db65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->