### PR TITLE
Container as non root and read only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,12 @@ RUN pnpm run build
 
 
 FROM builder
+ARG APP_UID=1000
+ARG APP_GID=1000
+
+RUN groupmod --non-unique --gid "${APP_GID}" node \
+  && usermod --non-unique --uid "${APP_UID}" --gid "${APP_GID}" node
+
 COPY --from=build --chown=node:node /app/node_modules /app/node_modules
 COPY --from=build --chown=node:node /app/dist /app/dist
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ FROM builder
 COPY --from=build --chown=node:node /app/node_modules /app/node_modules
 COPY --from=build --chown=node:node /app/dist /app/dist
 
+RUN mkdir -p /data \
+  && chown node:node /data
+
 # Environment variables
 ENV ACTUAL_SERVER_URL=""
 ENV ACTUAL_DATA_DIR=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY --from=build /app/dist /app/dist
 # Environment variables
 ENV ACTUAL_SERVER_URL=""
 # once a day at 1am in America/New_York
-ENV CRON_SCHEDULE="0 1 * * *" 
+ENV CRON_SCHEDULE="0 1 * * *"
 ENV LOG_LEVEL="info"
 ENV ACTUAL_BUDGET_SYNC_IDS=""
 ENV ENCRYPTION_PASSWORDS=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY --from=build /app/dist /app/dist
 
 # Environment variables
 ENV ACTUAL_SERVER_URL=""
+ENV ACTUAL_DATA_DIR=""
 # once a day at 1am in America/New_York
 ENV CRON_SCHEDULE="0 1 * * *"
 ENV LOG_LEVEL="info"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN pnpm run build
 
 
 FROM builder
-COPY --from=build /app/node_modules /app/node_modules
-COPY --from=build /app/dist /app/dist
+COPY --from=build --chown=node:node /app/node_modules /app/node_modules
+COPY --from=build --chown=node:node /app/dist /app/dist
 
 # Environment variables
 ENV ACTUAL_SERVER_URL=""
@@ -29,4 +29,5 @@ ENV ENCRYPTION_PASSWORDS=""
 ENV TIMEZONE="America/New_York"
 
 # Start the application
+USER node
 CMD ["node", "dist/src/index.js"]

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -12,6 +12,8 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
 WORKDIR /app
+RUN chown node:node /app
+RUN mkdir -p /data && chown node:node /data
 
 RUN chown node:node .
 
@@ -33,5 +35,5 @@ COPY --chown=node:node . .
 # Create e2e data directory
 RUN mkdir -p /app/e2e-data
 
-# Run e2e tests
-CMD ["pnpm", "test:e2e"]
+# Run e2e tests without invoking Corepack at runtime.
+CMD ["node", "node_modules/vitest/vitest.mjs", "run", "--config", "vitest.config.e2e.mts"]

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -13,19 +13,22 @@ ENV PATH="$PNPM_HOME:$PATH"
 
 WORKDIR /app
 
+RUN chown node:node .
+
 # Copy package files first for better layer caching
-COPY package.json pnpm-lock.yaml ./
+COPY --chown=node:node package.json pnpm-lock.yaml ./
 
 # Enable pnpm and install dependencies
 # The pnpm.onlyBuiltDependencies config in package.json allows better-sqlite3 build scripts
 # Use --ignore-scripts to skip lefthook install (requires git which isn't needed in E2E container)
 # Then rebuild better-sqlite3 native module which requires compilation
 RUN corepack enable
+USER node
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --ignore-scripts
 RUN pnpm rebuild better-sqlite3
 
 # Copy source files
-COPY . .
+COPY --chown=node:node . .
 
 # Create e2e data directory
 RUN mkdir -p /app/e2e-data

--- a/Dockerfile.mock-simplefin
+++ b/Dockerfile.mock-simplefin
@@ -12,19 +12,21 @@
 FROM node:24.13.0-slim
 
 WORKDIR /app
+RUN chown node:node /app
 
 # Install pnpm
 RUN npm install -g pnpm
 
 # Copy package files for dependency installation
-COPY package.json pnpm-lock.yaml ./
+COPY --chown=node:node package.json pnpm-lock.yaml ./
 
 # Install dependencies (ignore-scripts to skip lefthook which requires git)
+USER node
 RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # Copy mock SimpleFIN server source
-COPY src/__tests__/e2e/mock-simplefin/ ./src/__tests__/e2e/mock-simplefin/
-COPY tsconfig.json ./
+COPY --chown=node:node src/__tests__/e2e/mock-simplefin/ ./src/__tests__/e2e/mock-simplefin/
+COPY --chown=node:node tsconfig.json ./
 
 # Environment variables
 ENV MOCK_SIMPLEFIN_PORT=8080
@@ -34,12 +36,9 @@ ENV MOCK_SIMPLEFIN_PASSWORD=test123
 # Expose the port
 EXPOSE 8080
 
-# Install curl for health check
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
-
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:8080/health || exit 1
+  CMD node -e "fetch('http://localhost:8080/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 
 # Run the mock server with ts-node ESM loader
 USER node

--- a/Dockerfile.mock-simplefin
+++ b/Dockerfile.mock-simplefin
@@ -42,4 +42,5 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:8080/health || exit 1
 
 # Run the mock server with ts-node ESM loader
+USER node
 CMD ["node", "--loader", "ts-node/esm", "src/__tests__/e2e/mock-simplefin/standalone.ts"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The service requires the following environment variables:
 - `TIMEZONE`: Timezone for the cron job (default: `Etc/UTC`)
 - `RUN_ON_START`: Whether to run the sync on startup (default: `false`) - Please note that when setting this to `true`, you may get a notice email from SimpleFin (if you use that service), as they expect only a bank sync once a day.
 - `ENFORCE_READ_ONLY`: Optional hard-fail toggle for writable container root filesystems. Set `true` to enforce now (default: `false` for compatibility).
+- `RUNNING_IN_CONTAINER`: Optional container-detection override for uncommon runtimes. Set `true` to force container security checks when auto-detection misses (default: `false`).
 - `ACTUAL_DATA_DIR`: Deprecated legacy data directory override. Kept for compatibility only and planned for removal in the next major release.
 
 Container data defaults to `/data` inside the container.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,17 @@ The service requires the following environment variables:
 - `ENCRYPTION_PASSWORDS`: Comma-separated list of encryption passwords for each account in the ACTUAL_BUDGET_SYNC_IDS list (e.g. "password1,password2") or leave empty if you don't encrypt your data, the position of the password in the list is the position of the account in the ACTUAL_BUDGET_SYNC_IDS list; to skip an account add a comma to the list in that position
 - `TIMEZONE`: Timezone for the cron job (default: `Etc/UTC`)
 - `RUN_ON_START`: Whether to run the sync on startup (default: `false`) - Please note that when setting this to `true`, you may get a notice email from SimpleFin (if you use that service), as they expect only a bank sync once a day.
+- `ENFORCE_READ_ONLY`: Optional hard-fail toggle for writable container root filesystems. Set `true` to enforce now (default: `false` for compatibility).
+- `ACTUAL_DATA_DIR`: Deprecated legacy data directory override. Kept for compatibility only and planned for removal in the next major release.
+
+Container data defaults to `/data` inside the container.
 
 You can find your budget sync IDs in the Actual Budget app > _Selected Budget_ > Settings > Advanced Settings > Sync ID.
+
+### Deprecations
+
+- `ACTUAL_DATA_DIR` is deprecated and will be removed in the next major release. Use `/data` in containers and mount `/data` with tmpfs or a volume.
+- Writable container root filesystems are deprecated. In this release, startup warns by default; set `ENFORCE_READ_ONLY=true` to hard-fail now. A future major release will require read-only rootfs by default.
 
 ### Environment variables from files (Docker secrets)
 
@@ -80,12 +89,93 @@ For a pull request, maintainers can comment:
 
 The workflow will publish a test image with a tag like `seriouslag/actual-auto-sync:pr-<pr-number>-<sha8>` and reply on the PR with the full image name.
 
+### How to tune tmpfs size
+
+Adjust tmpfs size in your container runtime config, not via app environment variables:
+
+- `docker run`: update `tmpfs-size` in each `--mount type=tmpfs,...` argument.
+- `docker compose`: update `size=...` in each `tmpfs:` entry.
+
+Example:
+
+- `/data`: `512m` for typical usage, increase to `1g`+ for larger/more budgets.
+- `/tmp`: `128m` is usually enough, increase only if you see temp space errors.
+
+### Running as a custom uid/gid
+
+If you need host permission alignment or stricter runtime policies, you can customize uid/gid:
+
+- Build-time (image user id): pass `APP_UID` and `APP_GID` as Docker build args.
+- Runtime (container process id): pass `--user` in `docker run` or `user:` in compose.
+- Keep `tmpfs uid/gid` aligned with the runtime user so `/data` and `/tmp` remain writable.
+
+Build example:
+
+```bash
+docker build \
+  --build-arg APP_UID=12345 \
+  --build-arg APP_GID=12345 \
+  -t seriouslag/actual-auto-sync:custom-user .
+```
+
+Runtime example:
+
+```bash
+docker run -d \
+  --user 12345:12345 \
+  --read-only \
+  --mount type=tmpfs,destination=/data,tmpfs-size=536870912,tmpfs-mode=0700,uid=12345,gid=12345 \
+  --mount type=tmpfs,destination=/tmp,tmpfs-size=134217728,tmpfs-mode=1777,uid=12345,gid=12345 \
+  -e ACTUAL_SERVER_URL="your-server-url" \
+  -e ACTUAL_SERVER_PASSWORD="your-password" \
+  -e ACTUAL_BUDGET_SYNC_IDS="your-sync-id" \
+  seriouslag/actual-auto-sync:custom-user
+```
+
+Compose example:
+
+```yaml
+services:
+  actual-auto-sync:
+    image: seriouslag/actual-auto-sync:custom-user
+    user: '12345:12345'
+    read_only: true
+    tmpfs:
+      - /data:size=512m,mode=0700,uid=12345,gid=12345
+      - /tmp:size=128m,mode=1777,uid=12345,gid=12345
+```
+
+### Minimal run (compatibility mode)
+
+Use this if you want the simplest setup first (no deprecated options):
+
+```bash
+docker run -d \
+  -e ACTUAL_SERVER_URL="your-server-url" \
+  -e ACTUAL_SERVER_PASSWORD="your-password" \
+  -e ACTUAL_BUDGET_SYNC_IDS="your-sync-id" \
+  seriouslag/actual-auto-sync:latest
+```
+
+```yaml
+services:
+  actual-auto-sync:
+    image: seriouslag/actual-auto-sync:latest
+    environment:
+      - ACTUAL_SERVER_URL=your-server-url
+      - ACTUAL_SERVER_PASSWORD=your-password
+      - ACTUAL_BUDGET_SYNC_IDS=your-sync-id
+```
+
+This mode is supported for compatibility. For hardened production deployments, use read-only rootfs and tmpfs/volume mounts as shown below.
+
 ### direct docker run
 
 ```bash
 docker run -d \
   --read-only \
-  --mount type=tmpfs,destination=/data,tmpfs-mode=0770,uid=1000,gid=1000 \
+  --mount type=tmpfs,destination=/data,tmpfs-size=536870912,tmpfs-mode=0700,uid=1000,gid=1000 \
+  --mount type=tmpfs,destination=/tmp,tmpfs-size=134217728,tmpfs-mode=1777,uid=1000,gid=1000 \
   -e ACTUAL_SERVER_URL="your-server-url" \
   -e ACTUAL_SERVER_PASSWORD="your-password" \
   -e CRON_SCHEDULE="0 1 * * *" \
@@ -106,7 +196,8 @@ services:
     image: seriouslag/actual-auto-sync:latest
     read_only: true
     tmpfs:
-      - /data:size=10G,mode=0700,uid=1000,gid=1000
+      - /data:size=512m,mode=0700,uid=1000,gid=1000
+      - /tmp:size=128m,mode=1777,uid=1000,gid=1000
     environment:
       - ACTUAL_SERVER_URL=your-server-url
       - ACTUAL_SERVER_PASSWORD=your-password
@@ -127,7 +218,8 @@ services:
     image: seriouslag/actual-auto-sync:latest
     read_only: true
     tmpfs:
-      - /data:size=10G,mode=0700,uid=1000,gid=1000
+      - /data:size=512m,mode=0700,uid=1000,gid=1000
+      - /tmp:size=128m,mode=1777,uid=1000,gid=1000
     secrets:
       - actual_budget_sync_id
       - actual_server_password
@@ -157,6 +249,8 @@ Where files
 - `actual_server_password.txt`
 - `encryption_passwords.txt`
   are file text files next to your `docker-compose.yml` and containing your secrets
+
+The container checks whether the root filesystem is read-only at startup. By default it logs a deprecation warning if writable. Set `ENFORCE_READ_ONLY=true` to hard-fail when `--read-only`/`read_only: true` is missing.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The workflow will publish a test image with a tag like `seriouslag/actual-auto-s
 
 ```bash
 docker run -d \
+  --read-only \
+  --mount type=tmpfs,destination=/data,tmpfs-mode=0770,uid=1000,gid=1000 \
   -e ACTUAL_SERVER_URL="your-server-url" \
   -e ACTUAL_SERVER_PASSWORD="your-password" \
   -e CRON_SCHEDULE="0 1 * * *" \
@@ -102,6 +104,9 @@ services:
 ...
   actual-auto-sync:
     image: seriouslag/actual-auto-sync:latest
+    read_only: true
+    tmpfs:
+      - /data:size=10G,mode=0700,uid=1000,gid=1000
     environment:
       - ACTUAL_SERVER_URL=your-server-url
       - ACTUAL_SERVER_PASSWORD=your-password
@@ -120,6 +125,9 @@ services:
 ...
   actual-auto-sync:
     image: seriouslag/actual-auto-sync:latest
+    read_only: true
+    tmpfs:
+      - /data:size=10G,mode=0700,uid=1000,gid=1000
     secrets:
       - actual_budget_sync_id
       - actual_server_password

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -12,7 +12,13 @@ services:
       - MOCK_SIMPLEFIN_USERNAME=test
       - MOCK_SIMPLEFIN_PASSWORD=test123
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:8080/health']
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:8080/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))",
+        ]
       interval: 5s
       timeout: 5s
       retries: 3
@@ -40,6 +46,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.e2e
+    user: '${E2E_UID:-1000}:${E2E_GID:-1000}'
     depends_on:
       actual-server:
         condition: service_healthy
@@ -47,13 +54,18 @@ services:
         condition: service_healthy
     read_only: true
     tmpfs:
-      - /data:size=10G,mode=0700,uid=1000,gid=1000
-      - /app/node_modules/.vite-temp:size=100M,mode=0700,uid=1000,gid=1000
-      - /tmp:size=100M,mode=0700,uid=1000,gid=1000
+      - /data:size=256m,mode=0700,uid=${E2E_UID:-1000},gid=${E2E_GID:-1000}
+      - /tmp:size=128m,mode=1777,uid=${E2E_UID:-1000},gid=${E2E_GID:-1000}
+      - /app/node_modules/.vite-temp:size=64m,mode=0700,uid=${E2E_UID:-1000},gid=${E2E_GID:-1000}
     environment:
       - ACTUAL_SERVER_URL=http://actual-server:5006
       - ACTUAL_SERVER_PASSWORD=test-password-e2e
-      - ACTUAL_DATA_DIR=/app/e2e-data
+      - E2E_DATA_DIR=/data
+      - E2E_EXPECT_UID=${E2E_UID:-1000}
+      - E2E_EXPECT_GID=${E2E_GID:-1000}
+      - HOME=/tmp
+      - XDG_CACHE_HOME=/tmp/.cache
+      - COREPACK_HOME=/tmp/.cache/node/corepack
       # Mock SimpleFIN config (for mock server tests)
       - MOCK_SIMPLEFIN_PORT=8080
       - MOCK_SIMPLEFIN_URL=http://mock-simplefin:8080
@@ -69,9 +81,6 @@ services:
       - SIMPLEFIN_SETUP_TOKEN_2=${SIMPLEFIN_SETUP_TOKEN_2:-}
       - SIMPLEFIN_ACCESS_KEY_1=${SIMPLEFIN_ACCESS_KEY_1:-}
       - SIMPLEFIN_ACCESS_KEY_2=${SIMPLEFIN_ACCESS_KEY_2:-}
-    volumes:
-      - e2e-data:/app/e2e-data
 
 volumes:
   actual-data:
-  e2e-data:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -45,6 +45,11 @@ services:
         condition: service_healthy
       mock-simplefin:
         condition: service_healthy
+    read_only: true
+    tmpfs:
+      - /data:size=10G,mode=0700,uid=1000,gid=1000
+      - /app/node_modules/.vite-temp:size=100M,mode=0700,uid=1000,gid=1000
+      - /tmp:size=100M,mode=0700,uid=1000,gid=1000
     environment:
       - ACTUAL_SERVER_URL=http://actual-server:5006
       - ACTUAL_SERVER_PASSWORD=test-password-e2e

--- a/src/__tests__/container-security.test.ts
+++ b/src/__tests__/container-security.test.ts
@@ -1,0 +1,106 @@
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  enforceReadOnlyRootFilesystem,
+  isContainerRootFilesystemReadOnly,
+  isRootFilesystemReadOnly,
+  shouldEnforceReadOnlyRootFilesystem,
+} from '../container-security.js';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+
+const ROOT_RW_MOUNTINFO = '36 28 0:32 / / rw,relatime - overlay overlay rw,lowerdir=/foo';
+const ROOT_RO_MOUNTINFO = '36 28 0:32 / / ro,relatime - overlay overlay rw,lowerdir=/foo';
+
+describe('container-security', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('isRootFilesystemReadOnly', () => {
+    it('returns true when root mount has ro option', () => {
+      expect(isRootFilesystemReadOnly(ROOT_RO_MOUNTINFO)).toBe(true);
+    });
+
+    it('returns false when root mount is rw', () => {
+      expect(isRootFilesystemReadOnly(ROOT_RW_MOUNTINFO)).toBe(false);
+    });
+
+    it('throws when root mount entry is missing', () => {
+      expect(() => isRootFilesystemReadOnly('11 22 0:99 /tmp /tmp rw - tmpfs tmpfs rw')).toThrow(
+        'Unable to locate root mount entry in /proc/self/mountinfo',
+      );
+    });
+  });
+
+  describe('enforceReadOnlyRootFilesystem', () => {
+    it('skips validation outside containers', async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      await expect(enforceReadOnlyRootFilesystem()).resolves.toBeUndefined();
+      expect(readFile).not.toHaveBeenCalled();
+    });
+
+    it('passes when container root filesystem is read-only', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFile).mockResolvedValue(ROOT_RO_MOUNTINFO);
+
+      await expect(enforceReadOnlyRootFilesystem()).resolves.toBeUndefined();
+    });
+
+    it('fails when container root filesystem is writable', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFile).mockResolvedValue(ROOT_RW_MOUNTINFO);
+
+      await expect(enforceReadOnlyRootFilesystem()).rejects.toThrow(
+        'Container root filesystem is writable.',
+      );
+    });
+  });
+
+  describe('isContainerRootFilesystemReadOnly', () => {
+    it('returns non-container state outside containers', async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      await expect(isContainerRootFilesystemReadOnly()).resolves.toEqual({
+        isContainer: false,
+        isReadOnly: true,
+      });
+    });
+
+    it('returns container read-only state', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFile).mockResolvedValue(ROOT_RO_MOUNTINFO);
+
+      await expect(isContainerRootFilesystemReadOnly()).resolves.toEqual({
+        isContainer: true,
+        isReadOnly: true,
+      });
+    });
+  });
+
+  describe('shouldEnforceReadOnlyRootFilesystem', () => {
+    it('treats true-like values as enabled', () => {
+      expect(shouldEnforceReadOnlyRootFilesystem('true')).toBe(true);
+      expect(shouldEnforceReadOnlyRootFilesystem('1')).toBe(true);
+      expect(shouldEnforceReadOnlyRootFilesystem('yes')).toBe(true);
+      expect(shouldEnforceReadOnlyRootFilesystem('on')).toBe(true);
+    });
+
+    it('defaults to disabled for false-like and missing values', () => {
+      expect(shouldEnforceReadOnlyRootFilesystem(undefined)).toBe(false);
+      expect(shouldEnforceReadOnlyRootFilesystem('false')).toBe(false);
+      expect(shouldEnforceReadOnlyRootFilesystem('0')).toBe(false);
+      expect(shouldEnforceReadOnlyRootFilesystem('off')).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/container-security.test.ts
+++ b/src/__tests__/container-security.test.ts
@@ -52,9 +52,7 @@ describe('container-security', () => {
 
       await expect(enforceReadOnlyRootFilesystem()).resolves.toBeUndefined();
       expect(
-        vi
-          .mocked(readFile)
-          .mock.calls.some(([path]) => String(path) === '/proc/self/mountinfo'),
+        vi.mocked(readFile).mock.calls.some(([path]) => String(path) === '/proc/self/mountinfo'),
       ).toBe(false);
     });
 

--- a/src/__tests__/e2e/container-user.e2e.test.ts
+++ b/src/__tests__/e2e/container-user.e2e.test.ts
@@ -1,0 +1,73 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { E2E_CONFIG } from './setup.js';
+
+function isRootMountReadOnly(mountInfo: string): boolean {
+  const rootMountLine = mountInfo
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => {
+      if (!line || !line.includes(' - ')) {
+        return false;
+      }
+      const [leftSide] = line.split(' - ', 2);
+      const fields = leftSide.split(' ');
+      return fields[4] === '/';
+    });
+
+  if (!rootMountLine) {
+    throw new Error('Unable to locate root mount entry in /proc/self/mountinfo');
+  }
+
+  const [leftSide, rightSide] = rootMountLine.split(' - ', 2);
+  const mountFields = leftSide.split(' ');
+  const fsFields = rightSide.split(' ');
+  const mountOptions = new Set((mountFields[5] ?? '').split(','));
+  const superOptions = new Set((fsFields[2] ?? '').split(','));
+  return mountOptions.has('ro') || superOptions.has('ro');
+}
+
+describe('E2E: Container User Configuration', () => {
+  it('runs as the expected uid/gid when configured', () => {
+    const expectedUid = process.env.E2E_EXPECT_UID;
+    const expectedGid = process.env.E2E_EXPECT_GID;
+
+    if (typeof process.getuid !== 'function' || typeof process.getgid !== 'function') {
+      return;
+    }
+
+    if (expectedUid) {
+      expect(process.getuid()).toBe(Number(expectedUid));
+    }
+    if (expectedGid) {
+      expect(process.getgid()).toBe(Number(expectedGid));
+    }
+  });
+
+  it('can write to the configured e2e data directory', async () => {
+    const probePath = join(E2E_CONFIG.dataDir, `uid-gid-probe-${Date.now()}.txt`);
+
+    await mkdir(E2E_CONFIG.dataDir, { recursive: true });
+    await writeFile(probePath, 'ok', 'utf8');
+    const content = await readFile(probePath, 'utf8');
+    expect(content).toBe('ok');
+
+    await rm(probePath, { force: true });
+  });
+
+  it('runs with a read-only root filesystem', async () => {
+    const mountInfo = await readFile('/proc/self/mountinfo', 'utf8');
+    expect(isRootMountReadOnly(mountInfo)).toBe(true);
+  });
+
+  it('can write to /tmp when root filesystem is read-only', async () => {
+    const probePath = join('/tmp', `tmp-probe-${Date.now()}.txt`);
+    await writeFile(probePath, 'ok', 'utf8');
+    const content = await readFile(probePath, 'utf8');
+    expect(content).toBe('ok');
+    await rm(probePath, { force: true });
+  });
+});

--- a/src/__tests__/e2e/setup.ts
+++ b/src/__tests__/e2e/setup.ts
@@ -28,7 +28,7 @@ export type { BudgetMetadata } from './actual-api-helpers.js';
 export const E2E_CONFIG = {
   serverUrl: process.env.ACTUAL_SERVER_URL || 'http://localhost:5006',
   serverPassword: process.env.ACTUAL_SERVER_PASSWORD || 'test-password-e2e',
-  dataDir: process.env.ACTUAL_DATA_DIR || './e2e-data',
+  dataDir: process.env.E2E_DATA_DIR || './e2e-data',
 };
 
 /**

--- a/src/__tests__/env.test.ts
+++ b/src/__tests__/env.test.ts
@@ -190,13 +190,14 @@ describe('Environment Configuration', () => {
     });
 
     describe('ACTUAL_DATA_DIR', () => {
-      it('should accept directory strings', () => {
+      it('should accept directory strings when provided', () => {
         expect(() => actualDataDirSchema.parse('/data')).not.toThrow();
+        expect(() => actualDataDirSchema.parse('./legacy-data')).not.toThrow();
       });
 
-      it('should use default value when not provided', () => {
+      it('should remain optional for backward compatibility', () => {
         const result = actualDataDirSchema.parse(undefined);
-        expect(result).toBe('/data');
+        expect(result).toBeUndefined();
       });
     });
 

--- a/src/__tests__/env.test.ts
+++ b/src/__tests__/env.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  actualDataDirSchema,
   budgetIdSchema,
   cronScheduleSchema,
   encryptionPasswordSchema,
@@ -185,6 +186,17 @@ describe('Environment Configuration', () => {
       it('should use default value when not provided', () => {
         const result = timezoneSchema.parse(undefined);
         expect(result).toBe('Etc/UTC');
+      });
+    });
+
+    describe('ACTUAL_DATA_DIR', () => {
+      it('should accept directory strings', () => {
+        expect(() => actualDataDirSchema.parse('/data')).not.toThrow();
+      });
+
+      it('should use default value when not provided', () => {
+        const result = actualDataDirSchema.parse(undefined);
+        expect(result).toBe('/data');
       });
     });
 

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -17,6 +17,7 @@ import {
 
 // Mock external dependencies
 vi.mock('node:fs/promises', () => ({
+  access: vi.fn(),
   mkdir: vi.fn(),
   rm: vi.fn(),
   readdir: vi.fn(),

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -58,6 +58,7 @@ vi.mock('../env.js', () => ({
     ENCRYPTION_PASSWORDS: ['pass1', 'pass2'],
     TIMEZONE: 'Etc/UTC',
     RUN_ON_START: false,
+    ACTUAL_DATA_DIR: './data',
   },
 }));
 

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -17,7 +17,6 @@ import {
 
 // Mock external dependencies
 vi.mock('node:fs/promises', () => ({
-  access: vi.fn(),
   mkdir: vi.fn(),
   rm: vi.fn(),
   readdir: vi.fn(),

--- a/src/env.ts
+++ b/src/env.ts
@@ -95,9 +95,10 @@ export const serverUrlSchema = z.string().trim().min(1);
 export const serverPasswordSchema = z.string().min(1);
 
 /**
- * Actual data directory
+ * Deprecated data directory override.
+ * @deprecated Use /data in containers and mount /data via tmpfs/volume instead.
  */
-export const actualDataDirSchema = z.string().trim().optional().default('/data');
+export const actualDataDirSchema = z.string().trim().optional();
 
 export const env = createEnv({
   client: {},
@@ -127,6 +128,7 @@ export const env = createEnv({
    * `process.env` or `import.meta.env`.
    */
   runtimeEnv: {
+    ACTUAL_DATA_DIR: await getConfiguration('ACTUAL_DATA_DIR'),
     ACTUAL_BUDGET_SYNC_IDS: await getConfiguration('ACTUAL_BUDGET_SYNC_IDS'),
     ACTUAL_SERVER_PASSWORD: await getConfiguration('ACTUAL_SERVER_PASSWORD'),
     ACTUAL_SERVER_URL: await getConfiguration('ACTUAL_SERVER_URL'),
@@ -138,6 +140,7 @@ export const env = createEnv({
   },
 
   server: {
+    ACTUAL_DATA_DIR: actualDataDirSchema,
     ACTUAL_BUDGET_SYNC_IDS: budgetIdSchema,
     ACTUAL_SERVER_PASSWORD: serverPasswordSchema,
     ACTUAL_SERVER_URL: serverUrlSchema,
@@ -146,6 +149,5 @@ export const env = createEnv({
     LOG_LEVEL: logLevelSchema,
     RUN_ON_START: runOnStartSchema,
     TIMEZONE: timezoneSchema,
-    ACTUAL_DATA_DIR: actualDataDirSchema,
   },
 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -94,6 +94,11 @@ export const serverUrlSchema = z.string().trim().min(1);
  */
 export const serverPasswordSchema = z.string().min(1);
 
+/**
+ * Actual data directory
+ */
+export const actualDataDirSchema = z.string().trim().optional().default('/data');
+
 export const env = createEnv({
   client: {},
   /**
@@ -141,5 +146,6 @@ export const env = createEnv({
     LOG_LEVEL: logLevelSchema,
     RUN_ON_START: runOnStartSchema,
     TIMEZONE: timezoneSchema,
+    ACTUAL_DATA_DIR: actualDataDirSchema,
   },
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import type { Dirent } from 'node:fs';
+import { existsSync, type Dirent } from 'node:fs';
 import { mkdir, readFile, readdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -15,7 +15,15 @@ import cronstrue from 'cronstrue';
 import { env } from './env.js';
 import { logger } from './logger.js';
 
-const { ACTUAL_DATA_DIR } = env;
+const DEFAULT_ACTUAL_DATA_DIR = existsSync('/.dockerenv') ? '/data' : './data';
+const ACTUAL_DATA_DIR = env.ACTUAL_DATA_DIR ?? DEFAULT_ACTUAL_DATA_DIR;
+
+if (env.ACTUAL_DATA_DIR) {
+  logger.warn(
+    { actualDataDir: env.ACTUAL_DATA_DIR },
+    'ACTUAL_DATA_DIR is deprecated and will be removed in the next major release. Use /data in containers and mount it with tmpfs or a volume.',
+  );
+}
 // Keep retries small to avoid long loops while still healing transient API/session issues.
 const MAX_BUDGET_SYNC_ATTEMPTS = 2;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
-import { type Dirent, constants } from 'node:fs';
-import { access, mkdir, readFile, readdir, rm } from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
+import { mkdir, readFile, readdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import {
@@ -109,24 +109,11 @@ export async function syncAllAccounts() {
   await syncBudgetToServer();
 }
 
-async function testDataDirPermission() {
-  try {
-    logger.info(`Checking data directory write permission ${ACTUAL_DATA_DIR}`);
-    // eslint-disable-next-line no-bitwise
-    await access(ACTUAL_DATA_DIR, constants.R_OK | constants.W_OK);
-    logger.info('Data directory permission correct');
-  } catch (error) {
-    logger.error({ err: error }, 'Data directory permission incorrect');
-    throw error;
-  }
-}
-
 async function createDataDirAndInitApi() {
   try {
     logger.info(`Creating data directory ${ACTUAL_DATA_DIR}`);
     await mkdir(ACTUAL_DATA_DIR, { recursive: true });
     logger.info('Data directory created successfully.');
-    await testDataDirPermission();
     logger.info('Initializing Actual API...');
     await init({
       dataDir: ACTUAL_DATA_DIR,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
-import type { Dirent } from 'node:fs';
-import { mkdir, readFile, readdir, rm } from 'node:fs/promises';
+import { type Dirent, constants } from 'node:fs';
+import { access, mkdir, readFile, readdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import {
@@ -109,11 +109,24 @@ export async function syncAllAccounts() {
   await syncBudgetToServer();
 }
 
+async function testDataDirPermission() {
+  try {
+    logger.info(`Checking data directory write permission ${ACTUAL_DATA_DIR}`);
+    // eslint-disable-next-line no-bitwise
+    await access(ACTUAL_DATA_DIR, constants.R_OK | constants.W_OK);
+    logger.info('Data directory permission correct');
+  } catch (error) {
+    logger.error({ err: error }, 'Data directory permission incorrect');
+    throw error;
+  }
+}
+
 async function createDataDirAndInitApi() {
   try {
     logger.info(`Creating data directory ${ACTUAL_DATA_DIR}`);
     await mkdir(ACTUAL_DATA_DIR, { recursive: true });
     logger.info('Data directory created successfully.');
+    await testDataDirPermission();
     logger.info('Initializing Actual API...');
     await init({
       dataDir: ACTUAL_DATA_DIR,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,7 @@ import cronstrue from 'cronstrue';
 import { env } from './env.js';
 import { logger } from './logger.js';
 
-const ACTUAL_DATA_DIR = './data';
+const { ACTUAL_DATA_DIR } = env;
 // Keep retries small to avoid long loops while still healing transient API/session issues.
 const MAX_BUDGET_SYNC_ATTEMPTS = 2;
 

--- a/vitest.config.e2e.mts
+++ b/vitest.config.e2e.mts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  cacheDir: '/tmp/vitest-e2e',
   test: {
     globals: true,
     environment: 'node',

--- a/vitest.config.e2e.mts
+++ b/vitest.config.e2e.mts
@@ -1,7 +1,6 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  cacheDir: './node_modules/.cache/vitest-e2e',
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
Add an env variable `ACTUAL_DATA_DIR` to customize where the data is written.

User can mount this directory and make the container read only.

Process node is run as node user (uid=1000, gid=1000).

Possible improvement
1. customize the uid/gid of the user during build,
2. add to README that container can be run as user uid/gid.

Close https://github.com/seriouslag/actual-auto-sync/issues/79