### PR TITLE
feat: respect LOG_LEVEL for app and @actual-app/api output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The service requires the following environment variables:
 - `ACTUAL_SERVER_URL`: URL of your Actual Budget server
 - `ACTUAL_SERVER_PASSWORD`: Password for your Actual Budget server
 - `CRON_SCHEDULE`: Cron expression for scheduling syncs (default: `0 1 * * *` - daily at 1am)
-- `LOG_LEVEL`: Logging level (default: `info`)
+- `LOG_LEVEL`: Logging level — one of `debug`, `info`, `warn`, `error` (default: `info`). At `warn` or `error` the verbose console output from `@actual-app/api` is suppressed.
 - `ACTUAL_BUDGET_SYNC_IDS`: Comma-separated list of budget IDs to sync (e.g. "1cf9fbf9-97b7-4647-8128-8afec1b1fbe2,030d7094-aae8-4d70-aeee-9e29d30d9b88")
 - `ENCRYPTION_PASSWORDS`: Comma-separated list of encryption passwords for each account in the ACTUAL_BUDGET_SYNC_IDS list (e.g. "password1,password2") or leave empty if you don't encrypt your data, the position of the password in the list is the position of the account in the ACTUAL_BUDGET_SYNC_IDS list; to skip an account add a comma to the list in that position
 - `TIMEZONE`: Timezone for the cron job (default: `Etc/UTC`)

--- a/src/__tests__/env.test.ts
+++ b/src/__tests__/env.test.ts
@@ -24,7 +24,8 @@ vi.mock('pino', () => ({
 }));
 
 vi.mock('@t3-oss/env-core', () => ({
-  createEnv: vi.fn(),
+  // env.ts reads env.LOG_LEVEL after createEnv() to set the logger level.
+  createEnv: vi.fn(() => ({ LOG_LEVEL: 'info' })),
 }));
 
 describe('Environment Configuration', () => {

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -60,22 +60,29 @@ vi.mock('../env.js', () => ({
     ENCRYPTION_PASSWORDS: ['pass1', 'pass2'],
     TIMEZONE: 'Etc/UTC',
     RUN_ON_START: false,
+    LOG_LEVEL: 'info',
   },
 }));
 
-vi.mock('../logger.js', () => ({
-  logger: {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  },
-}));
+vi.mock('../logger.js', async (importOriginal) => {
+  // Keep the real isVerbose so the verbose flag passed to init() is exercised.
+  const actual = await importOriginal<typeof import('../logger.js')>();
+  return {
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    isVerbose: actual.isVerbose,
+  };
+});
 
 describe('utils.ts functions', () => {
   const mutableEnv = env as unknown as {
     ACTUAL_BUDGET_SYNC_IDS: string[];
     ENCRYPTION_PASSWORDS: string[];
+    LOG_LEVEL: string;
   };
   let cronstrueMock: { toString: ReturnType<typeof vi.fn> };
 
@@ -339,6 +346,7 @@ describe('utils.ts functions', () => {
       // Mock getSyncIdMaps to return a mapping that matches the env.ACTUAL_BUDGET_SYNC_IDS
       mutableEnv.ACTUAL_BUDGET_SYNC_IDS = ['budget1', 'budget2'];
       mutableEnv.ENCRYPTION_PASSWORDS = ['pass1', 'pass2'];
+      mutableEnv.LOG_LEVEL = 'info';
       vi.mocked(readdir).mockResolvedValue([
         { name: 'dir1', isDirectory: () => true },
         { name: 'dir2', isDirectory: () => true },
@@ -357,9 +365,26 @@ describe('utils.ts functions', () => {
         dataDir: './data',
         serverURL: 'http://localhost:5006',
         password: 'test-password',
+        verbose: true,
       });
       expect(cronstrueMock.toString).toHaveBeenCalledWith('0 0 * * *');
       expect(shutdown).toHaveBeenCalled();
+    });
+
+    it('initializes the API verbosely when LOG_LEVEL is verbose', async () => {
+      mutableEnv.LOG_LEVEL = 'info';
+
+      await sync();
+
+      expect(init).toHaveBeenCalledWith(expect.objectContaining({ verbose: true }));
+    });
+
+    it('initializes the API quietly when LOG_LEVEL is not verbose', async () => {
+      mutableEnv.LOG_LEVEL = 'warn';
+
+      await sync();
+
+      expect(init).toHaveBeenCalledWith(expect.objectContaining({ verbose: false }));
     });
 
     it('should download budgets without encryption password when password is missing', async () => {

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,17 +1,20 @@
 import { createEnv } from '@t3-oss/env-core';
 import { config } from 'dotenv';
 import { IANAZone } from 'luxon';
-import { pino } from 'pino';
 import { z } from 'zod';
 
 import { getConfiguration } from './docker-secret.js';
+import { isVerbose, logger } from './logger.js';
 
-const logger = pino({
-  level: 'info',
-});
+// Apply LOG_LEVEL as early as possible so dotenv and startup logs honor it.
+// At this point only system env is available (the .env file is loaded below),
+// which is enough to decide verbosity; the validated value is reapplied later.
+const earlyLogLevel = process.env.LOG_LEVEL ?? 'info';
+logger.level = earlyLogLevel;
 
 try {
-  config();
+  // `quiet` suppresses dotenv's own injection banner when not running verbose.
+  config({ quiet: !isVerbose(earlyLogLevel) });
   logger.info('Loaded environment variables from .env file.');
 } catch (error) {
   logger.warn({ err: error }, 'Unable to load .env file. Using system environment variables.');
@@ -143,3 +146,7 @@ export const env = createEnv({
     TIMEZONE: timezoneSchema,
   },
 });
+
+// Reapply the validated level (which may come from a docker secret rather than
+// process.env) now that the full configuration has been parsed.
+logger.level = env.LOG_LEVEL;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,7 +1,15 @@
 import { pino } from 'pino';
 
-import { env } from './env.js';
+// The level is configured from validated env in `env.ts` once it is available.
+// Keeping this module free of an `env` import avoids a circular dependency and
+// lets env.ts set the level (and decide log verbosity) during startup.
+export const logger = pino({});
 
-export const logger = pino({
-  level: env.LOG_LEVEL,
-});
+/**
+ * Whether the given log level should surface verbose third-party output, such
+ * as the noisy console logging emitted by `@actual-app/api` during sync. Only
+ * `debug`/`info` are considered verbose; `warn`/`error` keep the output quiet.
+ */
+export function isVerbose(logLevel: string): boolean {
+  return ['debug', 'info'].includes(logLevel);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ import { downloadBudget, init, runBankSync, shutdown, sync as syncBudget } from 
 import cronstrue from 'cronstrue';
 
 import { env } from './env.js';
-import { logger } from './logger.js';
+import { isVerbose, logger } from './logger.js';
 
 const ACTUAL_DATA_DIR = './data';
 // Keep retries small to avoid long loops while still healing transient API/session issues.
@@ -140,6 +140,8 @@ async function createDataDirAndInitApi() {
       dataDir: ACTUAL_DATA_DIR,
       serverURL: env.ACTUAL_SERVER_URL,
       password: env.ACTUAL_SERVER_PASSWORD,
+      // Silence @actual-app/api's verbose console output unless LOG_LEVEL opts in.
+      verbose: isVerbose(env.LOG_LEVEL),
     });
     logger.info('Actual API initialized successfully.');
   } catch (error) {


### PR DESCRIPTION
## Summary

Fixes `LOG_LEVEL` being ignored for most output (#77). Previously it only set pino's level; the flood of `[Breadcrumb]` / `Syncing since` / `PostError` lines (and dotenv's banner) came from sources pino doesn't control.

- **`logger.ts`** — remove the `env` import (breaks the `env` ↔ `logger` cycle so `env.ts` owns the level). Add `isVerbose()` (`debug`/`info` = verbose).
- **`env.ts`** — apply `LOG_LEVEL` early, pass `quiet: !isVerbose(level)` to dotenv, reapply the validated level after `createEnv()`.
- **`utils.ts`** — pass `verbose: isVerbose(env.LOG_LEVEL)` to `init()` so `@actual-app/api` stops writing breadcrumbs/sync chatter at `warn`/`error`.
- **README** — document accepted `LOG_LEVEL` values + suppression behavior.

## Test plan

- [x] `pnpm check` (lint + format + build) — clean
- [x] `pnpm test` — passes (adds two tests asserting `init` gets `verbose: true|false`)

_(Rebased onto `main` after the dependency bump #94 merged; previously stacked as #95.)_

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)