### PR TITLE
feat: add SKIP_FAILED_ACCOUNTS to isolate per-account bank sync failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The service requires the following environment variables:
 - `ENCRYPTION_PASSWORDS`: Comma-separated list of encryption passwords for each account in the ACTUAL_BUDGET_SYNC_IDS list (e.g. "password1,password2") or leave empty if you don't encrypt your data, the position of the password in the list is the position of the account in the ACTUAL_BUDGET_SYNC_IDS list; to skip an account add a comma to the list in that position
 - `TIMEZONE`: Timezone for the cron job (default: `Etc/UTC`)
 - `RUN_ON_START`: Whether to run the sync on startup (default: `false`) - Please note that when setting this to `true`, you may get a notice email from SimpleFin (if you use that service), as they expect only a bank sync once a day.
+- `SKIP_FAILED_ACCOUNTS`: Whether to sync each account individually and skip (rather than abort on) accounts that fail (default: `false`). When `false`, all accounts sync in a single request and any one failure aborts the budget's sync. When `true`, a failing account is logged and skipped so the rest still sync. Note: per-account syncing can result in more requests to your bank aggregator (e.g. SimpleFIN), which may matter for rate limits.
 
 You can find your budget sync IDs in the Actual Budget app > _Selected Budget_ > Settings > Advanced Settings > Sync ID.
 

--- a/src/__tests__/env.test.ts
+++ b/src/__tests__/env.test.ts
@@ -7,6 +7,7 @@ import {
   logLevelSchema,
   runOnStartSchema,
   serverPasswordSchema,
+  skipFailedAccountsSchema,
   serverUrlSchema,
   timezoneSchema,
 } from '../env.js';
@@ -223,6 +224,31 @@ describe('Environment Configuration', () => {
       it('should use default value when not provided', () => {
         const result = runOnStartSchema.parse(undefined);
         expect(result).toBe(false);
+      });
+    });
+
+    describe('SKIP_FAILED_ACCOUNTS', () => {
+      it('should coerce common truthy/falsy representations to boolean', () => {
+        const testCases = [
+          { input: true, expected: true },
+          { input: 'true', expected: true },
+          { input: '1', expected: true },
+          { input: 'yes', expected: true },
+          { input: 'on', expected: true },
+          { input: false, expected: false },
+          { input: 'false', expected: false },
+          { input: '0', expected: false },
+          { input: '', expected: false },
+          { input: 'nonsense', expected: false },
+        ];
+
+        for (const { input, expected } of testCases) {
+          expect(skipFailedAccountsSchema.parse(input)).toBe(expected);
+        }
+      });
+
+      it('should default to false when not provided', () => {
+        expect(skipFailedAccountsSchema.parse(undefined)).toBe(false);
       });
     });
   });

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import { readFile, readdir } from 'node:fs/promises';
 
-import { runBankSync, sync as syncBudget } from '@actual-app/api';
+import { getAccounts, runBankSync, sync as syncBudget } from '@actual-app/api';
 import cronstrue from 'cronstrue';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -27,6 +27,7 @@ vi.mock('@actual-app/api', () => ({
   init: vi.fn(),
   shutdown: vi.fn(),
   runBankSync: vi.fn(),
+  getAccounts: vi.fn(),
   downloadBudget: vi.fn(),
   loadBudget: vi.fn(),
   sync: vi.fn(),
@@ -61,6 +62,7 @@ vi.mock('../env.js', () => ({
     TIMEZONE: 'Etc/UTC',
     RUN_ON_START: false,
     LOG_LEVEL: 'info',
+    SKIP_FAILED_ACCOUNTS: false,
   },
 }));
 
@@ -83,11 +85,15 @@ describe('utils.ts functions', () => {
     ACTUAL_BUDGET_SYNC_IDS: string[];
     ENCRYPTION_PASSWORDS: string[];
     LOG_LEVEL: string;
+    SKIP_FAILED_ACCOUNTS: boolean;
   };
   let cronstrueMock: { toString: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset env knobs that individual tests toggle so ordering can't leak state.
+    mutableEnv.LOG_LEVEL = 'info';
+    mutableEnv.SKIP_FAILED_ACCOUNTS = false;
     cronstrueMock = cronstrue as unknown as {
       toString: ReturnType<typeof vi.fn>;
     };
@@ -117,6 +123,7 @@ describe('utils.ts functions', () => {
 
   describe('syncAllAccounts', () => {
     beforeEach(() => {
+      mutableEnv.SKIP_FAILED_ACCOUNTS = false;
       vi.mocked(mockDb.getAccounts).mockResolvedValue([
         { id: 'acc-1', balance_current: 12_345 },
         { id: 'acc-2', balance_current: null },
@@ -131,6 +138,9 @@ describe('utils.ts functions', () => {
       await syncAllAccounts(fakeApi);
 
       expect(logger.info).toHaveBeenCalledWith('Syncing all accounts...');
+      // Default mode: a single all-accounts sync, no per-account enumeration.
+      expect(runBankSync).toHaveBeenCalledWith();
+      expect(getAccounts).not.toHaveBeenCalled();
       expect(runBankSync).toHaveBeenCalled();
       expect(logger.info).toHaveBeenCalledWith('All accounts synced.');
       expect(logger.info).toHaveBeenCalledWith('Syncing account balances through CRDT...');
@@ -181,6 +191,64 @@ describe('utils.ts functions', () => {
       );
       expect(syncBudget).toHaveBeenCalled();
       expect(logger.info).toHaveBeenCalledWith('Budget synced to server successfully.');
+    });
+
+    describe('when SKIP_FAILED_ACCOUNTS is enabled', () => {
+      beforeEach(() => {
+        mutableEnv.SKIP_FAILED_ACCOUNTS = true;
+        vi.mocked(syncBudget).mockResolvedValue(undefined);
+        vi.mocked(getAccounts).mockResolvedValue([
+          { id: 'acc-1', name: 'Checking' },
+          { id: 'acc-2', name: 'Savings' },
+          { id: 'acc-3', name: 'Closed', closed: true },
+        ]);
+      });
+
+      it('syncs each non-closed account individually', async () => {
+        vi.mocked(runBankSync).mockResolvedValue(undefined);
+
+        await syncAllAccounts(fakeApi);
+
+        expect(runBankSync).toHaveBeenCalledTimes(2);
+        expect(runBankSync).toHaveBeenCalledWith({ accountId: 'acc-1' });
+        expect(runBankSync).toHaveBeenCalledWith({ accountId: 'acc-2' });
+        expect(runBankSync).not.toHaveBeenCalledWith({ accountId: 'acc-3' });
+        expect(syncBudget).toHaveBeenCalled();
+      });
+
+      it('skips a failing account, logs it, and still syncs the budget', async () => {
+        const error = new Error('internal error');
+        vi.mocked(runBankSync)
+          .mockRejectedValueOnce(error) // acc-1 fails
+          .mockResolvedValue(undefined); // acc-2 succeeds
+
+        await syncAllAccounts(fakeApi);
+
+        expect(runBankSync).toHaveBeenCalledTimes(2);
+        expect(logger.error).toHaveBeenCalledWith(
+          { err: error, accountId: 'acc-1', accountName: 'Checking' },
+          'Bank sync failed for account "Checking"; skipping.',
+        );
+        expect(logger.warn).toHaveBeenCalledWith(
+          { failedAccounts: ['Checking'] },
+          'Bank sync completed with 1 failed account(s): Checking.',
+        );
+        // Budget still pushed despite the failed account.
+        expect(syncBudget).toHaveBeenCalled();
+      });
+
+      it('labels a failing unnamed account by its id', async () => {
+        const error = new Error('boom');
+        vi.mocked(getAccounts).mockResolvedValue([{ id: 'acc-x', name: '' }]);
+        vi.mocked(runBankSync).mockRejectedValue(error);
+
+        await syncAllAccounts(fakeApi);
+
+        expect(logger.error).toHaveBeenCalledWith(
+          { err: error, accountId: 'acc-x', accountName: '' },
+          'Bank sync failed for account "acc-x"; skipping.',
+        );
+      });
     });
   });
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -40,35 +40,50 @@ export const encryptionPasswordSchema = z
 export const cronScheduleSchema = z.string().trim().min(9).default('0 1 * * *');
 
 /**
+ * Builds a schema that parses common truthy/falsy string representations (and
+ * real booleans) into a boolean, defaulting to `false` for unknown values.
+ */
+function flexibleBooleanSchema() {
+  return z
+    .union([z.string(), z.boolean()])
+    .optional()
+    .default(false)
+    .transform((value) => {
+      const loweredValue = typeof value === 'string' ? value.trim().toLowerCase() : value;
+      switch (loweredValue) {
+        case true:
+        case 'on':
+        case 'yes':
+        case '1':
+        case 'true': {
+          return true;
+        }
+        case false:
+        case 'off':
+        case 'no':
+        case '0':
+        case 'false': {
+          return false;
+        }
+        default: {
+          return false;
+        }
+      }
+    });
+}
+
+/**
  * Default to false
  * @default false
  */
-export const runOnStartSchema = z
-  .union([z.string(), z.boolean()])
-  .optional()
-  .default(false)
-  .transform((value) => {
-    const loweredValue = typeof value === 'string' ? value.trim().toLowerCase() : value;
-    switch (loweredValue) {
-      case true:
-      case 'on':
-      case 'yes':
-      case '1':
-      case 'true': {
-        return true;
-      }
-      case false:
-      case 'off':
-      case 'no':
-      case '0':
-      case 'false': {
-        return false;
-      }
-      default: {
-        return false;
-      }
-    }
-  });
+export const runOnStartSchema = flexibleBooleanSchema();
+
+/**
+ * When true, bank sync runs per-account and skips accounts that fail instead of
+ * aborting the whole budget. Default false (single all-accounts sync).
+ * @default false
+ */
+export const skipFailedAccountsSchema = flexibleBooleanSchema();
 
 /**
  * Default to info
@@ -132,6 +147,7 @@ export const env = createEnv({
     ENCRYPTION_PASSWORDS: await getConfiguration('ENCRYPTION_PASSWORDS'),
     LOG_LEVEL: await getConfiguration('LOG_LEVEL'),
     RUN_ON_START: await getConfiguration('RUN_ON_START'),
+    SKIP_FAILED_ACCOUNTS: await getConfiguration('SKIP_FAILED_ACCOUNTS'),
     TIMEZONE: await getConfiguration('TIMEZONE'),
   },
 
@@ -143,6 +159,7 @@ export const env = createEnv({
     ENCRYPTION_PASSWORDS: encryptionPasswordSchema,
     LOG_LEVEL: logLevelSchema,
     RUN_ON_START: runOnStartSchema,
+    SKIP_FAILED_ACCOUNTS: skipFailedAccountsSchema,
     TIMEZONE: timezoneSchema,
   },
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,14 @@ import type { Dirent } from 'node:fs';
 import { mkdir, readFile, readdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { downloadBudget, init, runBankSync, shutdown, sync as syncBudget } from '@actual-app/api';
+import {
+  downloadBudget,
+  getAccounts,
+  init,
+  runBankSync,
+  shutdown,
+  sync as syncBudget,
+} from '@actual-app/api';
 import cronstrue from 'cronstrue';
 
 import { env } from './env.js';
@@ -104,9 +111,43 @@ export async function syncAccountBalancesToCRDT(api: BalanceSyncApi) {
   return !hasSyncErrors;
 }
 
+/**
+ * Runs bank sync per account, skipping (and logging) any that fail so one bad
+ * account does not abort the rest. Returns the names/ids of accounts that failed.
+ */
+async function runBankSyncSkippingFailures(): Promise<string[]> {
+  const accounts = (await getAccounts()).filter((account) => !account.closed);
+  const failedAccounts: string[] = [];
+
+  for (const account of accounts) {
+    const label = account.name || account.id;
+    try {
+      await runBankSync({ accountId: account.id });
+    } catch (error) {
+      failedAccounts.push(label);
+      logger.error(
+        { err: error, accountId: account.id, accountName: account.name },
+        `Bank sync failed for account "${label}"; skipping.`,
+      );
+    }
+  }
+
+  return failedAccounts;
+}
+
 async function syncBankAccounts(api: BalanceSyncApi) {
   logger.info('Syncing all accounts...');
-  await runBankSync();
+  if (env.SKIP_FAILED_ACCOUNTS) {
+    const failedAccounts = await runBankSyncSkippingFailures();
+    if (failedAccounts.length > 0) {
+      logger.warn(
+        { failedAccounts },
+        `Bank sync completed with ${failedAccounts.length} failed account(s): ${failedAccounts.join(', ')}.`,
+      );
+    }
+  } else {
+    await runBankSync();
+  }
   logger.info('All accounts synced.');
   logger.info('Syncing account balances through CRDT...');
   const syncedBalances = await syncAccountBalancesToCRDT(api);


### PR DESCRIPTION
## Summary

Adds an opt-in way to stop one bad account from aborting the whole budget sync (#88, and the partial-failure case in #93).

Today `runBankSync()` syncs every account in one all-or-nothing call — if one account errors, nothing imports. With `SKIP_FAILED_ACCOUNTS=true` the service enumerates accounts and runs `runBankSync({ accountId })` per (non-closed) account, logging and skipping failures, then still pushes the budget for the ones that succeeded.

- **`env.ts`** — extract a shared `flexibleBooleanSchema()` (reused by `RUN_ON_START`), add `skipFailedAccountsSchema` + the `SKIP_FAILED_ACCOUNTS` var
- **`utils.ts`** — branch in `syncBankAccounts`: per-account loop with isolation when enabled, otherwise the existing single sync
- **README** — document the flag + its rate-limit tradeoff

**Default behavior unchanged.** Opt-in chosen deliberately: per-account syncing can mean more requests to bank aggregators like SimpleFIN (rate limits / "one sync a day" emails), so only users who need resilience turn it on.

## Test plan

- [x] `pnpm check` — clean
- [x] `pnpm test` — 91/91 pass; 100% branch coverage on `utils.ts`

_(Rebased onto `main` after #94 and #97 merged; previously stacked as #96.)_

Closes #88
Helps #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)