### PR TITLE
feat: run container as non-root with read-only-friendly data dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,17 +15,35 @@ RUN pnpm run build
 
 
 FROM builder
-COPY --from=build /app/node_modules /app/node_modules
-COPY --from=build /app/dist /app/dist
+# UID/GID of the runtime user. Override at build time to match a host user, e.g.
+# `docker build --build-arg APP_UID=1001 --build-arg APP_GID=1001 .`
+ARG APP_UID=1000
+ARG APP_GID=1000
+
+# Repoint the pre-existing `node` user/group to the requested UID/GID.
+RUN groupmod --non-unique --gid "${APP_GID}" node \
+  && usermod --non-unique --uid "${APP_UID}" --gid "${APP_GID}" node
+
+COPY --from=build --chown=node:node /app/node_modules /app/node_modules
+COPY --from=build --chown=node:node /app/dist /app/dist
+
+# Writable data directory owned by the runtime user so the rest of the root
+# filesystem can be mounted read-only.
+RUN mkdir -p /data && chown node:node /data
 
 # Environment variables
 ENV ACTUAL_SERVER_URL=""
+# Keep budget data/caches on the writable mount so `--read-only` works.
+ENV ACTUAL_DATA_DIR="/data"
 # once a day at 1am in America/New_York
-ENV CRON_SCHEDULE="0 1 * * *" 
+ENV CRON_SCHEDULE="0 1 * * *"
 ENV LOG_LEVEL="info"
 ENV ACTUAL_BUDGET_SYNC_IDS=""
 ENV ENCRYPTION_PASSWORDS=""
 ENV TIMEZONE="America/New_York"
+
+# Run as the unprivileged node user
+USER node
 
 # Start the application
 CMD ["node", "dist/src/index.js"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The service requires the following environment variables:
 - `TIMEZONE`: Timezone for the cron job (default: `Etc/UTC`)
 - `RUN_ON_START`: Whether to run the sync on startup (default: `false`) - Please note that when setting this to `true`, you may get a notice email from SimpleFin (if you use that service), as they expect only a bank sync once a day.
 - `SKIP_FAILED_ACCOUNTS`: Whether to sync each account individually and skip (rather than abort on) accounts that fail (default: `false`). When `false`, all accounts sync in a single request and any one failure aborts the budget's sync. When `true`, a failing account is logged and skipped so the rest still sync. Note: per-account syncing can result in more requests to your bank aggregator (e.g. SimpleFIN), which may matter for rate limits.
+- `ACTUAL_DATA_DIR`: Directory where budget data and caches are written (default: `./data`; `/data` in the Docker image). Point this at a mounted/tmpfs path to run the container with a read-only root filesystem.
 
 You can find your budget sync IDs in the Actual Budget app > _Selected Budget_ > Settings > Advanced Settings > Sync ID.
 
@@ -150,6 +151,29 @@ Where files
 - `actual_server_password.txt`
 - `encryption_passwords.txt`
   are file text files next to your `docker-compose.yml` and containing your secrets
+
+### Running as non-root with a read-only filesystem
+
+The image runs as the unprivileged `node` user (uid/gid `1000`) by default. The only path the app needs to write is its data directory, which defaults to `ACTUAL_DATA_DIR=/data` in the image. Mount that as a writable volume (or tmpfs) and you can lock the rest of the container down with a read-only root filesystem:
+
+```yaml
+services:
+  actual-auto-sync:
+    image: seriouslag/actual-auto-sync:latest
+    read_only: true
+    volumes:
+      - ./actual-auto-sync-data:/data
+    environment:
+      - ACTUAL_SERVER_URL=your-server-url
+      - ACTUAL_SERVER_PASSWORD=your-password
+      - ACTUAL_BUDGET_SYNC_IDS=1cf9fbf9-97b7-4647-8128-8afec1b1fbe2
+```
+
+The host-mounted directory must be writable by uid/gid `1000`. To match a different host user, build the image with custom ids:
+
+```bash
+docker build --build-arg APP_UID=1001 --build-arg APP_GID=1001 -t actual-auto-sync .
+```
 
 ## Development
 

--- a/src/__tests__/env.test.ts
+++ b/src/__tests__/env.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  actualDataDirSchema,
   budgetIdSchema,
   cronScheduleSchema,
   encryptionPasswordSchema,
@@ -249,6 +250,20 @@ describe('Environment Configuration', () => {
 
       it('should default to false when not provided', () => {
         expect(skipFailedAccountsSchema.parse(undefined)).toBe(false);
+      });
+    });
+
+    describe('ACTUAL_DATA_DIR', () => {
+      it('should default to ./data when not provided', () => {
+        expect(actualDataDirSchema.parse(undefined)).toBe('./data');
+      });
+
+      it('should accept and trim a custom path', () => {
+        expect(actualDataDirSchema.parse('  /data  ')).toBe('/data');
+      });
+
+      it('should reject an empty string', () => {
+        expect(() => actualDataDirSchema.parse('')).toThrow();
       });
     });
   });

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -56,6 +56,7 @@ vi.mock('../env.js', () => ({
   env: {
     ACTUAL_SERVER_URL: 'http://localhost:5006',
     ACTUAL_SERVER_PASSWORD: 'test-password',
+    ACTUAL_DATA_DIR: './data',
     CRON_SCHEDULE: '0 0 * * *',
     ACTUAL_BUDGET_SYNC_IDS: ['budget1', 'budget2'],
     ENCRYPTION_PASSWORDS: ['pass1', 'pass2'],

--- a/src/env.ts
+++ b/src/env.ts
@@ -112,6 +112,13 @@ export const serverUrlSchema = z.string().trim().min(1);
  */
 export const serverPasswordSchema = z.string().min(1);
 
+/**
+ * Directory where the Actual API writes budget data and caches. Override it to a
+ * mounted/tmpfs path so the container can run with a read-only root filesystem.
+ * @default "./data"
+ */
+export const actualDataDirSchema = z.string().trim().min(1).default('./data');
+
 export const env = createEnv({
   client: {},
   /**
@@ -141,6 +148,7 @@ export const env = createEnv({
    */
   runtimeEnv: {
     ACTUAL_BUDGET_SYNC_IDS: await getConfiguration('ACTUAL_BUDGET_SYNC_IDS'),
+    ACTUAL_DATA_DIR: await getConfiguration('ACTUAL_DATA_DIR'),
     ACTUAL_SERVER_PASSWORD: await getConfiguration('ACTUAL_SERVER_PASSWORD'),
     ACTUAL_SERVER_URL: await getConfiguration('ACTUAL_SERVER_URL'),
     CRON_SCHEDULE: await getConfiguration('CRON_SCHEDULE'),
@@ -153,6 +161,7 @@ export const env = createEnv({
 
   server: {
     ACTUAL_BUDGET_SYNC_IDS: budgetIdSchema,
+    ACTUAL_DATA_DIR: actualDataDirSchema,
     ACTUAL_SERVER_PASSWORD: serverPasswordSchema,
     ACTUAL_SERVER_URL: serverUrlSchema,
     CRON_SCHEDULE: cronScheduleSchema,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,9 @@ import cronstrue from 'cronstrue';
 import { env } from './env.js';
 import { isVerbose, logger } from './logger.js';
 
-const ACTUAL_DATA_DIR = './data';
+// Configurable so the writable data dir can live on a mounted/tmpfs path,
+// allowing the container to run with a read-only root filesystem.
+const ACTUAL_DATA_DIR = env.ACTUAL_DATA_DIR;
 // Keep retries small to avoid long loops while still healing transient API/session issues.
 const MAX_BUDGET_SYNC_ATTEMPTS = 2;
 


### PR DESCRIPTION
## Summary

Implements the core of community PR #81 (#79): run the image as the unprivileged `node` user, and make the writable data directory configurable so the container can run with a read-only root filesystem.

- **Dockerfile** — repoint the `node` user/group to `APP_UID`/`APP_GID` build args (default `1000`), `--chown` the app, create a writable `/data` owned by `node`, default `ACTUAL_DATA_DIR=/data`, and `USER node`.
- **`env.ts`** — add `actualDataDirSchema` (`ACTUAL_DATA_DIR`, default `./data`).
- **`utils.ts`** — write budget data/caches to `env.ACTUAL_DATA_DIR` instead of a hardcoded `./data`.
- **README** — document non-root + read-only usage (with a `read_only: true` compose example) and the `ACTUAL_DATA_DIR` / `APP_UID` / `APP_GID` knobs.
- **tests** — schema coverage for `ACTUAL_DATA_DIR`.

Credit to **@Noneangel** (original PR #81) — co-authored.

## Deliberately scoped out of #81

The `container-security.ts` runtime module (133 lines) that parses `/proc/self/mountinfo` + cgroups to *enforce* a read-only root FS via new `ENFORCE_READ_ONLY` / `RUNNING_IN_CONTAINER` env vars. It's fragile (heuristic container detection) and its throw-on-not-readonly behavior could break existing deployments — worth its own discussion rather than bundling into the non-root change.

## Test plan

- [x] `pnpm check` — clean
- [x] `pnpm test` — 94/94 pass, 100% branch coverage on `utils.ts`
- [ ] ⚠️ **Docker image build not verified locally** (no Docker daemon available). The PR CI e2e uses `Dockerfile.e2e`, not the shipped `Dockerfile`, so the `node`-user/`usermod` changes aren't exercised by CI. Recommend building a test image (the `/publish-test-image` maintainer comment) or a local `docker build` before merge, and a quick `docker run ... id` to confirm uid `1000` + a read-only run.

Closes #79