### PR TITLE
style: format copilot-instructions.md to satisfy oxfmt

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,7 @@
 **Prerequisites:** Node.js >= 22, pnpm >= 10.8.1
 
 **Commands:**
+
 - `pnpm install --frozen-lockfile` - Install dependencies
 - `pnpm build` - Compile TypeScript
 - `pnpm test` - Run tests
@@ -15,35 +16,41 @@ Always run build and tests before committing changes.
 ## Code Style and Conventions
 
 ### TypeScript
+
 - Use strict TypeScript (ES2024, NodeNext modules)
 - **Always include `.js` extensions in import statements** (ESM requirement)
 - Use type-safe environment variable validation with zod schemas
 
 ### Testing
+
 - Use Vitest for all tests
 - Test files: `src/__tests__/*.test.ts`
 - Write unit tests for all new functionality
 - Maintain high test coverage
 
 ### Environment Variables
+
 - Define all environment variables in `src/env.ts` using zod schemas
 - Use @t3-oss/env-core package for type-safe validation
 - Document in both env.ts and README.md
 - Add tests in `src/__tests__/env.test.ts`
 
 ### Logging
+
 - Use pino logger from `src/logger.ts`
 - Never log sensitive information (passwords, encryption keys, API tokens)
 
 ## Common Tasks
 
 ### Adding a new environment variable
+
 1. Add schema to `src/env.ts` using zod
 2. Add to env configuration object
 3. Document in README.md
 4. Add tests in `src/__tests__/env.test.ts`
 
 ### Modifying sync logic
+
 - Main entry point: `src/index.ts`
 - Cron job creation: `src/cron.ts`
 - Test thoroughly - affects users' financial data


### PR DESCRIPTION
The `.github/copilot-instructions.md` merged in #57 was never run through oxfmt, so `format:check` now fails on `main` (and is blocking other PRs like #74). This adds the blank-lines-after-headings that oxfmt expects — no content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)