### PR TITLE
ci: bump GitHub Actions to current majors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -25,7 +25,7 @@ jobs:
           node-version: '24.17.0'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.34.4
           run_install: false
@@ -62,7 +62,7 @@ jobs:
         run: pnpm test:e2e:docker
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
@@ -163,16 +163,16 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: seriouslag
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/pr-publish-test-image.yml
+++ b/.github/workflows/pr-publish-test-image.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Reply unauthorized
         if: steps.permission.outputs.authorized != 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({
@@ -47,7 +47,7 @@ jobs:
 
       - name: Checkout PR head
         if: steps.permission.outputs.authorized == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
 
@@ -65,18 +65,18 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.permission.outputs.authorized == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
         if: steps.permission.outputs.authorized == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: seriouslag
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push test image
         if: steps.permission.outputs.authorized == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -84,7 +84,7 @@ jobs:
 
       - name: Reply with published image
         if: success() && steps.permission.outputs.authorized == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           IMAGE_NAME: ${{ steps.image.outputs.image_name }}
         with:
@@ -98,7 +98,7 @@ jobs:
 
       - name: Reply publish failure
         if: failure() && steps.permission.outputs.authorized == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -22,7 +22,7 @@ jobs:
           node-version: '24.17.0'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.34.4
           run_install: false
@@ -59,7 +59,7 @@ jobs:
         run: pnpm test:e2e:docker
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true


### PR DESCRIPTION
## Summary

The safe half of Renovate **#85**, split out. Bumps the GitHub Actions used in CI to their current major versions:

| Action | From → To |
|--------|-----------|
| actions/checkout | v6 → v7 |
| actions/github-script | v8 → v9 |
| pnpm/action-setup | v4 → v6 |
| codecov/codecov-action | v5 → v7 |
| docker/setup-buildx-action | v3 → v4 |
| docker/login-action | v3 → v4 |
| docker/build-push-action | v6 → v7 |

pnpm stays at **10.34.4** (from #74).

## Why pnpm v11 is deferred (not in this PR)

Validated locally that #85's pnpm v11 bump has two breaking behaviors that need their own PR:

1. **`pnpm.onlyBuiltDependencies` is no longer read from `package.json`** in pnpm 11 — it must move to `pnpm-workspace.yaml`, or `better-sqlite3`/`esbuild`/`lefthook` won't run their build scripts (the app needs `better-sqlite3`'s native binding).
2. **pnpm 11 enables a default `minimumReleaseAge` supply-chain policy** that rejects very recently published packages — a fresh install failed on `nanoid@3.3.15` (published <24h prior). That's time-dependent and would flake CI; it needs a deliberate policy decision + clean lockfile regen.

I'll open a separate pnpm v11 PR that does the `pnpm-workspace.yaml` migration, regenerates the lockfile under pnpm 11, and moves the CI `version:`/`packageManager` in lockstep. **Renovate #85 will be closed** in favor of this PR + that follow-up.

## Test plan
- [x] `pnpm check` + `pnpm test` (94/94) pass on pnpm 10.34.4
- [x] CI re-runs all jobs with the new action versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)