### PR TITLE
ci: build the shipped Dockerfile and assert non-root in PR CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,3 +64,24 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
           fail_ci_if_error: false
+
+  # Builds the shipped Dockerfile (the e2e job builds Dockerfile.e2e, so the
+  # production image is otherwise never exercised in CI) and verifies it runs
+  # unprivileged as uid 1000.
+  docker-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build production image
+        run: docker build -t actual-auto-sync:ci .
+
+      - name: Verify the image runs as non-root (uid 1000)
+        run: |
+          uid="$(docker run --rm --entrypoint sh actual-auto-sync:ci -c 'id -u')"
+          echo "runtime uid: ${uid}"
+          if [ "${uid}" != "1000" ]; then
+            echo "::error::expected the container to run as uid 1000, got ${uid}"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Closes the CI blind spot from §6 of the review: the e2e job builds `Dockerfile.e2e`, so the **shipped `Dockerfile` is never built in CI**. A non-root/`usermod` regression or a bad base-image bump could ship unnoticed — it nearly did when #99 introduced the `node` user (only a local `docker build` caught it).

Adds a parallel `docker-image` job to `pr.yml` that:
- `docker build`s the production `Dockerfile`
- asserts the container runs as **uid 1000** (non-root)

## Notes
- Runs in parallel with `build-and-test`; adds a new `docker-image` status check.
- Related process gap (separate, needs repo-admin): the `main` ruleset has **no `required_status_checks` rule**, so none of these checks actually gate merges. Recommend adding one (incl. this new job) — see the PR discussion. Not done here since it changes merge requirements for all contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)