### PR TITLE
chore: migrate to pnpm 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10.34.4
+          version: 11.8.0
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10.34.4
+          version: 11.8.0
           run_install: false
 
       - name: Get pnpm store directory

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -13,11 +13,12 @@ ENV PATH="$PNPM_HOME:$PATH"
 
 WORKDIR /app
 
-# Copy package files first for better layer caching
-COPY package.json pnpm-lock.yaml ./
+# Copy package files first for better layer caching.
+# pnpm-workspace.yaml carries pnpm 11 settings (allowBuilds, minimumReleaseAge)
+# and must be present before install.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
-# Enable pnpm and install dependencies
-# The pnpm.onlyBuiltDependencies config in package.json allows better-sqlite3 build scripts
+# Enable pnpm (corepack pins the version from package.json "packageManager").
 # Use --ignore-scripts to skip lefthook install (requires git which isn't needed in E2E container)
 # Then rebuild better-sqlite3 native module which requires compilation
 RUN corepack enable

--- a/Dockerfile.mock-simplefin
+++ b/Dockerfile.mock-simplefin
@@ -13,11 +13,13 @@ FROM node:24.17.0-slim
 
 WORKDIR /app
 
-# Install pnpm
-RUN npm install -g pnpm
+# Enable pnpm (corepack pins the version from package.json "packageManager")
+RUN corepack enable
 
-# Copy package files for dependency installation
-COPY package.json pnpm-lock.yaml ./
+# Copy package files for dependency installation.
+# pnpm-workspace.yaml carries pnpm 11 settings (minimumReleaseAge) and must be
+# present before install.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Install dependencies (ignore-scripts to skip lefthook which requires git)
 RUN pnpm install --frozen-lockfile --ignore-scripts

--- a/package.json
+++ b/package.json
@@ -51,12 +51,5 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   },
-  "packageManager": "pnpm@10.34.4",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "lefthook"
-    ]
-  }
+  "packageManager": "pnpm@11.8.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,15 @@
-onlyBuiltDependencies:
-  - better-sqlite3
-  - esbuild
+# pnpm 11 approves dependency build scripts via `allowBuilds` (it no longer
+# reads the package.json "pnpm".onlyBuiltDependencies field). better-sqlite3
+# needs its native binding built; esbuild and lefthook have install scripts.
+allowBuilds:
+  better-sqlite3: true
+  esbuild: true
+  lefthook: true
+
+# pnpm 11 enables a default minimumReleaseAge (~1 day) supply-chain gate that
+# rejects freshly published packages. With a committed lockfile + reviewed
+# Renovate PRs as the supply-chain control, that default only makes CI
+# non-deterministic (it fails whenever a dep was published <1 day ago). Disable
+# it to match the prior pnpm 10 behavior; set a positive value in minutes to
+# re-enable the delay.
+minimumReleaseAge: 0


### PR DESCRIPTION
## Summary

Completes the deferred half of Renovate #85 — the pnpm 10 → 11 bump, done properly. pnpm 11 has several breaking behaviors I had to handle (all validated locally + with a production `docker build`):

| pnpm 11 change | Handling |
|----------------|----------|
| No longer reads `pnpm.onlyBuiltDependencies` from `package.json`; uses `allowBuilds` in `pnpm-workspace.yaml` | Migrated `better-sqlite3`/`esbuild`/`lefthook` to `allowBuilds: true` (without this, `better-sqlite3`'s native binding silently doesn't build) |
| New default `minimumReleaseAge` (~1 day) supply-chain gate rejects freshly-published packages | Set `minimumReleaseAge: 0` — it otherwise flakes CI non-deterministically (it failed on `nanoid@3.3.15`, published <1 day prior). The committed lockfile + reviewed Renovate PRs remain the supply-chain control; documented how to re-enable |
| `packageManager` / CI pnpm pin | Bumped to `pnpm@11.8.0` in `package.json` + `pnpm/action-setup` in `main.yml`/`pr.yml`. Dockerfiles use corepack, so they pick it up automatically |

Lockfile format is **unchanged** (pnpm 11 reads the existing lockfile as-is).

## Test plan
- [x] `CI=true pnpm install --frozen-lockfile` under pnpm 11.8.0 — clean
- [x] `pnpm check` + `pnpm test` — 94/94
- [x] `node -e "require('better-sqlite3')"` — native binding loads
- [x] `docker build` + `docker run` — image builds, runs as **uid 1000**, `better-sqlite3` loads in-container
- [x] Will be gated by the new required `build-and-test` + `docker-image` checks

Closes the pnpm portion of #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)