### PR TITLE
chore(renovate): automerge monthly lockFileMaintenance + enable OSV alerts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,11 @@
 {
   "extends": ["config:recommended"],
   "dependencyDashboard": true,
+  "osvVulnerabilityAlerts": true,
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "schedule": ["before 4am on the first day of the month"],
+    "automerge": true
   },
   "labels": ["dependencies"],
   "rangeStrategy": "bump",


### PR DESCRIPTION
## Summary

Stops the recurring, manually-closed "Lock file maintenance" PRs (#76 → #103 → #105 …) **without** losing transitive-dependency security hygiene.

- **`lockFileMaintenance`** → monthly schedule + `automerge: true`. Now that `build-and-test` + `docker-image` are *required* checks, a lockfile-only refresh is safe to auto-merge — CI (incl. e2e + a real Docker build) blocks it if a refreshed transitive dep breaks anything. Net effect: zero-touch transitive-dep freshness instead of weekly manual closes.
- **`osvVulnerabilityAlerts: true`** → a CVE path (including transitive deps) that doesn't depend on GitHub Dependabot.
- Also enabled **GitHub Dependabot alerts + automated security fixes** in repo settings (they were off — which is *why* disabling lockFileMaintenance would have been a real security gap).

## Why not just disable it?

With Dependabot alerts off and no OSV config, `lockFileMaintenance` was the *only* automatic mechanism refreshing transitive deps — so plain-disabling would have removed the sole path for security fixes buried in the dependency tree. This change keeps that path (now zero-touch) and adds a proper CVE alerting floor on top.

## Validation
- [x] `renovate-config-validator` — "Config validated successfully"
- [x] `pnpm check` + `format:check` clean
- [x] Gated by required `build-and-test` + `docker-image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)