### PR TITLE
Add daily repository stats workflow

### DIFF
--- a/.github/repo-stats.json
+++ b/.github/repo-stats.json
@@ -1,0 +1,22 @@
+{
+  "generatedAt": null,
+  "window": {
+    "timezone": "America/Indiana/Indianapolis",
+    "previousDayStart": null,
+    "previousDayEnd": null
+  },
+  "repositories": [
+    {
+      "fullName": "seriouslag/actual-auto-sync",
+      "stars": null,
+      "newStarsPreviousDay": 0,
+      "newStargazersPreviousDay": []
+    },
+    {
+      "fullName": "seriouslag/openapi-ts-nx-plugin",
+      "stars": null,
+      "newStarsPreviousDay": 0,
+      "newStargazersPreviousDay": []
+    }
+  ]
+}

--- a/.github/scripts/update-repo-stats.mjs
+++ b/.github/scripts/update-repo-stats.mjs
@@ -1,0 +1,114 @@
+import fs from 'node:fs/promises';
+
+const token = process.env.GITHUB_TOKEN;
+
+if (!token) {
+  throw new Error('GITHUB_TOKEN is required.');
+}
+
+const repos = [
+  { owner: 'seriouslag', repo: 'actual-auto-sync' },
+  { owner: 'seriouslag', repo: 'openapi-ts-nx-plugin' },
+];
+
+const timeZone = 'America/Indiana/Indianapolis';
+
+const getParts = (date) => {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    day: '2-digit',
+    month: '2-digit',
+    timeZone,
+    year: 'numeric',
+  }).formatToParts(date);
+
+  return Object.fromEntries(parts.map((part) => [part.type, part.value]));
+};
+
+const getLocalDateKey = (date) => {
+  const parts = getParts(date);
+  return `${parts.year}-${parts.month}-${parts.day}`;
+};
+
+const githubFetch = async (url, options = {}) => {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${token}`,
+      'x-github-api-version': '2022-11-28',
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub API request failed: ${response.status} ${body}`);
+  }
+
+  return response;
+};
+
+const getRepository = async ({ owner, repo }) => {
+  const response = await githubFetch(`https://api.github.com/repos/${owner}/${repo}`);
+  return response.json();
+};
+
+const getStargazers = async ({ owner, repo }) => {
+  const stargazers = [];
+  let page = 1;
+
+  while (true) {
+    const url = `https://api.github.com/repos/${owner}/${repo}/stargazers?per_page=100&page=${page}`;
+    const response = await githubFetch(url, {
+      headers: { accept: 'application/vnd.github.star+json' },
+    });
+    const pageItems = await response.json();
+
+    stargazers.push(...pageItems);
+
+    if (pageItems.length < 100) break;
+    page += 1;
+  }
+
+  return stargazers;
+};
+
+const now = new Date();
+const todayParts = getParts(now);
+const todayUtcMidnight = new Date(
+  `${todayParts.year}-${todayParts.month}-${todayParts.day}T00:00:00Z`,
+);
+const previousDayUtcMidnight = new Date(todayUtcMidnight.getTime() - 24 * 60 * 60 * 1000);
+const previousDayKey = getLocalDateKey(previousDayUtcMidnight);
+
+const repositories = [];
+
+for (const repoRef of repos) {
+  const repository = await getRepository(repoRef);
+  const stargazers = await getStargazers(repoRef);
+  const newStargazersPreviousDay = stargazers
+    .filter((stargazer) => getLocalDateKey(new Date(stargazer.starred_at)) === previousDayKey)
+    .map((stargazer) => ({
+      htmlUrl: stargazer.user?.html_url ?? null,
+      login: stargazer.user?.login ?? null,
+      starredAt: stargazer.starred_at,
+    }));
+
+  repositories.push({
+    fullName: `${repoRef.owner}/${repoRef.repo}`,
+    newStargazersPreviousDay,
+    newStarsPreviousDay: newStargazersPreviousDay.length,
+    stars: repository.stargazers_count,
+  });
+}
+
+const output = {
+  generatedAt: now.toISOString(),
+  repositories,
+  window: {
+    previousDay: previousDayKey,
+    timezone: timeZone,
+  },
+};
+
+await fs.writeFile('.github/repo-stats.json', `${JSON.stringify(output, null, 2)}\n`);

--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -3,12 +3,7 @@ name: Repository Stats
 on:
   workflow_dispatch:
   schedule:
-    # Runs daily at 8:15 AM America/Indiana/Indianapolis during EDT.
-    # Note: GitHub cron uses UTC and does not auto-adjust for DST.
-    - cron: "15 12 * * *"
-
-permissions:
-  contents: write
+    - cron: '15 12 * * *'
 
 jobs:
   update-repo-stats:
@@ -18,108 +13,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Generate repository stats
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-
-            const repos = [
-              { owner: 'seriouslag', repo: 'actual-auto-sync' },
-              { owner: 'seriouslag', repo: 'openapi-ts-nx-plugin' },
-            ];
-
-            const timeZone = 'America/Indiana/Indianapolis';
-
-            const getParts = (date) => {
-              const parts = new Intl.DateTimeFormat('en-US', {
-                timeZone,
-                year: 'numeric',
-                month: '2-digit',
-                day: '2-digit',
-              }).formatToParts(date);
-
-              return Object.fromEntries(parts.map((part) => [part.type, part.value]));
-            };
-
-            const now = new Date();
-            const todayParts = getParts(now);
-            const todayUtcMidnight = new Date(`${todayParts.year}-${todayParts.month}-${todayParts.day}T00:00:00Z`);
-            const previousDayUtcMidnight = new Date(todayUtcMidnight.getTime() - 24 * 60 * 60 * 1000);
-            const previousDayParts = getParts(previousDayUtcMidnight);
-
-            // Build previous calendar day boundaries in the target timezone.
-            // Indianapolis is currently UTC-04 during EDT and UTC-05 during EST.
-            // This uses GitHub-hosted Node's timezone formatting to select the calendar day,
-            // then filters stargazer timestamps by that day in the same timezone.
-            const previousDayKey = `${previousDayParts.year}-${previousDayParts.month}-${previousDayParts.day}`;
-
-            const getLocalDateKey = (date) => {
-              const parts = getParts(date);
-              return `${parts.year}-${parts.month}-${parts.day}`;
-            };
-
-            async function getNewStargazersPreviousDay(owner, repo) {
-              const newStargazers = [];
-
-              for await (const response of github.paginate.iterator(
-                github.rest.activity.listStargazersForRepo,
-                {
-                  owner,
-                  repo,
-                  per_page: 100,
-                  headers: {
-                    accept: 'application/vnd.github.star+json',
-                  },
-                },
-              )) {
-                for (const item of response.data) {
-                  const starredAt = item.starred_at;
-                  if (!starredAt) continue;
-
-                  const starredDate = new Date(starredAt);
-                  const starredDayKey = getLocalDateKey(starredDate);
-
-                  if (starredDayKey === previousDayKey) {
-                    newStargazers.push({
-                      login: item.user?.login ?? null,
-                      htmlUrl: item.user?.html_url ?? null,
-                      starredAt,
-                    });
-                  }
-                }
-              }
-
-              return newStargazers;
-            }
-
-            const stats = [];
-
-            for (const { owner, repo } of repos) {
-              const repository = await github.rest.repos.get({ owner, repo });
-              const newStargazers = await getNewStargazersPreviousDay(owner, repo);
-
-              stats.push({
-                fullName: `${owner}/${repo}`,
-                stars: repository.data.stargazers_count,
-                newStarsPreviousDay: newStargazers.length,
-                newStargazersPreviousDay: newStargazers,
-              });
-            }
-
-            const output = {
-              generatedAt: now.toISOString(),
-              window: {
-                timezone: timeZone,
-                previousDay: previousDayKey,
-              },
-              repositories: stats,
-            };
-
-            fs.writeFileSync('.github/repo-stats.json', `${JSON.stringify(output, null, 2)}\n`);
-
-      - name: Commit repository stats
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "chore: update repository stats"
-          file_pattern: .github/repo-stats.json
+      - name: Placeholder
+        run: echo 'Repository stats workflow placeholder'

--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -1,0 +1,125 @@
+name: Repository Stats
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs daily at 8:15 AM America/Indiana/Indianapolis during EDT.
+    # Note: GitHub cron uses UTC and does not auto-adjust for DST.
+    - cron: "15 12 * * *"
+
+permissions:
+  contents: write
+
+jobs:
+  update-repo-stats:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate repository stats
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const repos = [
+              { owner: 'seriouslag', repo: 'actual-auto-sync' },
+              { owner: 'seriouslag', repo: 'openapi-ts-nx-plugin' },
+            ];
+
+            const timeZone = 'America/Indiana/Indianapolis';
+
+            const getParts = (date) => {
+              const parts = new Intl.DateTimeFormat('en-US', {
+                timeZone,
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+              }).formatToParts(date);
+
+              return Object.fromEntries(parts.map((part) => [part.type, part.value]));
+            };
+
+            const now = new Date();
+            const todayParts = getParts(now);
+            const todayUtcMidnight = new Date(`${todayParts.year}-${todayParts.month}-${todayParts.day}T00:00:00Z`);
+            const previousDayUtcMidnight = new Date(todayUtcMidnight.getTime() - 24 * 60 * 60 * 1000);
+            const previousDayParts = getParts(previousDayUtcMidnight);
+
+            // Build previous calendar day boundaries in the target timezone.
+            // Indianapolis is currently UTC-04 during EDT and UTC-05 during EST.
+            // This uses GitHub-hosted Node's timezone formatting to select the calendar day,
+            // then filters stargazer timestamps by that day in the same timezone.
+            const previousDayKey = `${previousDayParts.year}-${previousDayParts.month}-${previousDayParts.day}`;
+
+            const getLocalDateKey = (date) => {
+              const parts = getParts(date);
+              return `${parts.year}-${parts.month}-${parts.day}`;
+            };
+
+            async function getNewStargazersPreviousDay(owner, repo) {
+              const newStargazers = [];
+
+              for await (const response of github.paginate.iterator(
+                github.rest.activity.listStargazersForRepo,
+                {
+                  owner,
+                  repo,
+                  per_page: 100,
+                  headers: {
+                    accept: 'application/vnd.github.star+json',
+                  },
+                },
+              )) {
+                for (const item of response.data) {
+                  const starredAt = item.starred_at;
+                  if (!starredAt) continue;
+
+                  const starredDate = new Date(starredAt);
+                  const starredDayKey = getLocalDateKey(starredDate);
+
+                  if (starredDayKey === previousDayKey) {
+                    newStargazers.push({
+                      login: item.user?.login ?? null,
+                      htmlUrl: item.user?.html_url ?? null,
+                      starredAt,
+                    });
+                  }
+                }
+              }
+
+              return newStargazers;
+            }
+
+            const stats = [];
+
+            for (const { owner, repo } of repos) {
+              const repository = await github.rest.repos.get({ owner, repo });
+              const newStargazers = await getNewStargazersPreviousDay(owner, repo);
+
+              stats.push({
+                fullName: `${owner}/${repo}`,
+                stars: repository.data.stargazers_count,
+                newStarsPreviousDay: newStargazers.length,
+                newStargazersPreviousDay: newStargazers,
+              });
+            }
+
+            const output = {
+              generatedAt: now.toISOString(),
+              window: {
+                timezone: timeZone,
+                previousDay: previousDayKey,
+              },
+              repositories: stats,
+            };
+
+            fs.writeFileSync('.github/repo-stats.json', `${JSON.stringify(output, null, 2)}\n`);
+
+      - name: Commit repository stats
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update repository stats"
+          file_pattern: .github/repo-stats.json

--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '15 12 * * *'
 
+permissions:
+  contents: write
+
 jobs:
   update-repo-stats:
     runs-on: ubuntu-latest
@@ -13,5 +16,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Placeholder
-        run: echo 'Repository stats workflow placeholder'
+      - name: Generate repository stats
+        run: node .github/scripts/update-repo-stats.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit repository stats
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: update repository stats'
+          file_pattern: .github/repo-stats.json


### PR DESCRIPTION
## Summary

- Add a scheduled GitHub Actions workflow to generate repository star statistics.
- Add `.github/repo-stats.json` as the generated output file.
- Track both `seriouslag/actual-auto-sync` and `seriouslag/openapi-ts-nx-plugin`.

This is intended to support ChatGPT daily summaries of repository activity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated repository statistics generation that runs daily and can also be triggered on demand.
  * Repository stats are now captured into a shared JSON report, including per-project star totals and the list/count of new stars from the previous day (with timezone-aware day boundaries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->