### PR TITLE
Limit repo stats to current repository

### DIFF
--- a/.github/scripts/update-repo-stats.mjs
+++ b/.github/scripts/update-repo-stats.mjs
@@ -6,10 +6,7 @@ if (!token) {
   throw new Error('GITHUB_TOKEN is required.');
 }
 
-const repos = [
-  { owner: 'seriouslag', repo: 'actual-auto-sync' },
-  { owner: 'seriouslag', repo: 'openapi-ts-nx-plugin' },
-];
+const repos = [{ owner: 'seriouslag', repo: 'actual-auto-sync' }];
 
 const timeZone = 'America/Indiana/Indianapolis';
 


### PR DESCRIPTION
## Summary

- Limit the stats script to only collect stats for seriouslag/actual-auto-sync.
- Avoid cross-repository token permission issues.

After this is merged and tested, the same pattern can be copied into seriouslag/openapi-ts-nx-plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository statistics generation to track only one repository.
  * Removed stats for the previously included repository, so the published stats file now reflects the narrower scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->