### PR TITLE
Publish repo stats to issue

### DIFF
--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -6,7 +6,8 @@ on:
     - cron: '15 12 * * *'
 
 permissions:
-  contents: write
+  contents: read
+  issues: write
 
 jobs:
   update-repo-stats:
@@ -21,8 +22,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Commit repository stats
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: 'chore: update repository stats'
-          file_pattern: .github/repo-stats.json
+      - name: Prepare issue body
+        run: |
+          {
+            echo '# Repository Stats'
+            echo
+            echo '```json'
+            cat .github/repo-stats.json
+            echo '```'
+          } > repo-stats-issue.md
+
+      - name: Publish issue
+        run: |
+          issue_number=$(gh issue list --label repo-stats --state open --json number,title --jq '.[] | select(.title == "Repository Stats") | .number' | head -n 1)
+
+          if [ -n "$issue_number" ]; then
+            gh issue edit "$issue_number" --body-file repo-stats-issue.md
+          else
+            gh issue create --title 'Repository Stats' --label repo-stats --body-file repo-stats-issue.md
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Stop committing generated repository stats back to the protected main branch.
- Generate the existing `.github/repo-stats.json` during the workflow run.
- Publish the generated JSON into a public GitHub issue titled `Repository Stats` with label `repo-stats`.

This keeps the stats publicly pollable without requiring workflow commits to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository stats handling to publish the stats as an open issue instead of committing a stats file back to the repo.
  * Reduced repository permissions by switching file access to read-only while keeping issue updates enabled.
  * Improved the stats update flow so it refreshes an existing issue when possible, or creates a new one if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->