### PR TITLE
Fix repository stats issue publishing

### DIFF
--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -39,7 +39,7 @@ jobs:
           if [ -n "$issue_number" ]; then
             gh issue edit "$issue_number" --body-file repo-stats-issue.md
           else
-            gh issue create --title 'Repository Stats' --label repo-stats --body-file repo-stats-issue.md
+            gh issue create --title 'Repository Stats' --body-file repo-stats-issue.md
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Use a new branch created from current main.
- Keep the repository stats issue publishing workflow.
- Create the Repository Stats issue without requiring the repo-stats label to already exist.

This avoids reusing the previously squashed branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated issue publishing flow so newly created “Repository Stats” issues are no longer tagged with a specific label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->