### PR TITLE
docs: fix typo in docker secrets README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Where files
 - `actual_budget_sync_id.txt`
 - `actual_server_password.txt`
 - `encryption_passwords.txt`
-  are file text files next to your `docker-compose.yml` and containing your secrets
+  are plain text files next to your `docker-compose.yml` and containing your secrets
 
 ### Running as non-root with a read-only filesystem
 


### PR DESCRIPTION
## Summary
- Fixes a typo in the "Running with docker compose with docker secrets" section: "are file text files" → "are plain text files"

## Test plan
- Docs-only change, no functional testing needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the Docker secrets setup instructions by describing `_FILE` secret contents as “plain text files” for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->