### PR TITLE
feat: publish multi-arch (arm64) Docker images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,6 +162,9 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -176,4 +179,5 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker_tags.outputs.tags }}

--- a/.github/workflows/pr-publish-test-image.yml
+++ b/.github/workflows/pr-publish-test-image.yml
@@ -63,6 +63,10 @@ jobs:
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           echo "image_name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU
+        if: steps.permission.outputs.authorized == 'true'
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         if: steps.permission.outputs.authorized == 'true'
         uses: docker/setup-buildx-action@v4
@@ -80,6 +84,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.image.outputs.image_name }}
 
       - name: Reply with published image

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ services:
 
 ## Running with Docker (pull from Docker Hub)
 
-Images are published as multi-arch manifests for `linux/amd64` and `linux/arm64`, so `docker pull` / `docker run` automatically selects the right build for your host (including ARM devices such as a Raspberry Pi 4/5, Apple Silicon, or ARM-based NAS/servers).
+Images are published as multi-arch manifests for `linux/amd64` and `linux/arm64`, so `docker pull` / `docker run` automatically selects the right build for your host. The `linux/arm64` image requires a 64-bit ARM (ARM64/aarch64) operating system — for example Apple Silicon, an ARM-based NAS/server, or a Raspberry Pi 4/5 running a 64-bit OS. A 32-bit ARM OS (such as 32-bit Raspberry Pi OS) cannot use the `linux/arm64` image.
 
 Published tags include:
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ services:
 
 ## Running with Docker (pull from Docker Hub)
 
+Images are published as multi-arch manifests for `linux/amd64` and `linux/arm64`, so `docker pull` / `docker run` automatically selects the right build for your host (including ARM devices such as a Raspberry Pi 4/5, Apple Silicon, or ARM-based NAS/servers).
+
 Published tags include:
 
 - `latest` for the newest successful `main` build


### PR DESCRIPTION
## Summary

Publishes Docker images as multi-arch manifests for **`linux/amd64` + `linux/arm64`** from both the main-branch publish workflow and the PR `/publish-test-image` workflow.

Resolves discussion [#113](https://github.com/seriouslag/actual-auto-sync/discussions/113) — "DockerHub linux/arm64 support?".

## Changes

- **`.github/workflows/main.yml`** — add `docker/setup-qemu-action` + `platforms: linux/amd64,linux/arm64` on the publish step. All existing tags (`latest`, `vX.Y.Z.N`, `<sha>`) become multi-arch manifests.
- **`.github/workflows/pr-publish-test-image.yml`** — same additions (existing `authorized` guard preserved) so PR test images validate arm64 before merge.
- **`README.md`** — note multi-arch support under the pull section.

## Why no Dockerfile changes

The only native dependency is `better-sqlite3` (pulled in transitively by `@actual-app/api`/`@actual-app/core`; we never import it directly). It installs via `prebuild-install`, and an **arm64 glibc prebuild exists for Node 24 (ABI 137)** — matching `node:24.18.0-slim`. So the image is already architecture-agnostic; only the build workflow needed to be told to target both platforms.

## Trade-off

The arm64 stage builds under QEMU emulation on the amd64 runner. Because `better-sqlite3` is a prebuild download (no compile), the extra cost is mostly emulated `pnpm install` + `tsc` — a few minutes, not a huge jump. If a prebuild were ever missing, the source-compile fallback fails loudly in the slim image rather than producing a broken image.

## Validation

After merge, verify both arches landed:

\`\`\`bash
docker buildx imagetools inspect seriouslag/actual-auto-sync:latest
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D32np8bK3sZzALtiayy93c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker images now support both AMD64 and ARM64 architectures.
  * Docker automatically selects the appropriate image for the host device, including ARM-based systems.

* **Documentation**
  * Updated Docker usage guidance to explain multi-architecture image support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->