### PR TITLE
feat: support 32-bit ARM (linux/arm/v7) via Node 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24.18.0'
+          node-version: '22.23.1'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -179,5 +179,5 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ steps.docker_tags.outputs.tags }}

--- a/.github/workflows/pr-publish-test-image.yml
+++ b/.github/workflows/pr-publish-test-image.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ steps.image.outputs.image_name }}
 
       - name: Reply with published image

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24.18.0'
+          node-version: '22.23.1'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -68,11 +68,11 @@ jobs:
   # Builds the shipped Dockerfile (the e2e job builds Dockerfile.e2e, so the
   # production image is otherwise never exercised in CI) for every published
   # platform, then verifies each image runs unprivileged as uid 1000 and can
-  # load its native better-sqlite3 binary. The arm64 build runs under QEMU
-  # emulation and catches arch-specific build/prebuild regressions pre-merge,
+  # load its native better-sqlite3 binary. The arm64 and arm/v7 builds run under
+  # QEMU emulation and catch arch-specific build/prebuild regressions pre-merge,
   # before the main-branch publish assembles the multi-arch manifest.
   #
-  # Both platforms are exercised in a single job (rather than a matrix) so the
+  # All platforms are exercised in a single job (rather than a matrix) so the
   # status-check context stays named `docker-image` — a matrix would emit
   # `docker-image (linux/amd64)` / `(linux/arm64)` instead and break any branch
   # protection rule that requires the `docker-image` context.
@@ -88,10 +88,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build and verify production image (amd64 + arm64)
+      - name: Build and verify production image (amd64 + arm64 + arm/v7)
         run: |
           set -euo pipefail
-          for platform in linux/amd64 linux/arm64; do
+          for platform in linux/amd64 linux/arm64 linux/arm/v7; do
             echo "::group::Build + verify ${platform}"
             docker buildx build --platform "${platform}" --load -t actual-auto-sync:ci .
 
@@ -103,7 +103,7 @@ jobs:
             fi
 
             # Load the native SQLite binary and run a query — this is the
-            # arch-specific risk (the arm64 prebuild must match the runtime ABI).
+            # arch-specific risk (each arch's prebuild must match the runtime ABI).
             docker run --rm --platform "${platform}" --entrypoint node actual-auto-sync:ci \
               -e "const D=require('better-sqlite3'); const db=new D(':memory:'); if (db.prepare('select 42 as n').get().n !== 42) { process.exit(1); } console.log('better-sqlite3 OK on', process.arch);"
             echo "::endgroup::"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:24.18.0-slim AS builder
+FROM node:22.23.1-slim AS builder
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,5 +1,5 @@
 # E2E Test Dockerfile
-FROM node:24.18.0-slim
+FROM node:22.23.1-slim
 
 # Install build dependencies for native modules (better-sqlite3)
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile.mock-simplefin
+++ b/Dockerfile.mock-simplefin
@@ -9,7 +9,7 @@
 # Run:
 #   docker run -p 8080:8080 mock-simplefin
 
-FROM node:24.18.0-slim
+FROM node:22.23.1-slim
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,15 @@ services:
 
 ## Running with Docker (pull from Docker Hub)
 
-Images are published as multi-arch manifests for `linux/amd64` and `linux/arm64`, so `docker pull` / `docker run` automatically selects the right build for your host. The `linux/arm64` image requires a 64-bit ARM (ARM64/aarch64) operating system — for example Apple Silicon, an ARM-based NAS/server, or a Raspberry Pi 4/5 running a 64-bit OS. A 32-bit ARM OS (such as 32-bit Raspberry Pi OS) cannot use the `linux/arm64` image.
+Images are published as multi-arch manifests, so `docker pull` / `docker run` automatically selects the right build for your host.
+
+**Supported platforms:**
+
+- `linux/amd64` — x86-64 (Intel/AMD)
+- `linux/arm64` — 64-bit ARM (ARM64/aarch64), e.g. Apple Silicon, an ARM-based NAS/server, or a Raspberry Pi 4/5 running a 64-bit OS
+- `linux/arm/v7` — 32-bit ARM (ARMv7/armhf), e.g. a Raspberry Pi 2/3 or a Pi running a 32-bit OS
+
+This matches the platforms published by the upstream [Actual Budget server](https://hub.docker.com/r/actualbudget/actual-server), so the sync service runs anywhere the server does. On 32-bit ARM the process is limited to a ~2–3 GB address space, which is ample for syncing but worth noting for very large budgets.
 
 Published tags include:
 


### PR DESCRIPTION
## Summary

Adds **`linux/arm/v7`** (32-bit ARM) to the published images, matching the platform coverage — and Node major — of the upstream Actual Budget server.

## The catch, and the fix

Node 24 dropped official 32-bit ARM (`armv7l`) binaries, so `node:24-slim` has no `linux/arm/v7` variant — v7 couldn't just be added to the platform list. Node **22 LTS** still ships `armv7l` and `node:22-slim` publishes an `arm/v7` image, so this moves the base image (and CI runner) from Node 24 → Node 22.

Verified the upstream `actualbudget/actual-server` arm/v7 image itself runs **Node v22.23.1**, so this puts us on the same runtime, not out on a limb. `better-sqlite3` ships a 32-bit ARM prebuild for Node 22 (ABI 127) — no toolchain changes.

## Changes

- `Dockerfile`, `Dockerfile.e2e`, `Dockerfile.mock-simplefin` — `node:24.18.0-slim` → `node:22.23.1-slim`
- `.github/workflows/{main,pr}.yml` — CI runner Node `24.18.0` → `22.23.1` (test on what we ship)
- `main.yml` + `pr-publish-test-image.yml` — publish `linux/amd64,linux/arm64,linux/arm/v7`
- `pr.yml` `docker-image` — build + smoke-test all three arches (uid 1000 + native `better-sqlite3` load)
- `README.md` — supported-platforms list incl. arm/v7, with the 32-bit ~2–3 GB address-space note

## Local validation

Built the production Dockerfile for `linux/arm/v7` under QEMU and ran it:

```
arch: arm | node: v22.23.1 | better-sqlite3: 42
uid: 1000
```

The PR's own `docker-image` check exercises all three arches; post-merge I'll confirm the published `:latest` manifest carries `linux/arm/v7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D32np8bK3sZzALtiayy93c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker images now support `linux/amd64`, `linux/arm64`, and `linux/arm/v7` platforms.

* **Documentation**
  * Updated Docker usage guidance to list supported platforms and note 32-bit ARM memory limitations.

* **Chores**
  * Standardized build and test environments on Node.js 22.23.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->