### PR TITLE
fix(ci): authenticate repo stats workflow with a PAT

### DIFF
--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Generate and publish repository stats
         uses: actions/github-script@v9
         with:
+          # Listing stargazers is restricted to repo admins/collaborators as of
+          # July 2026; github-actions[bot] is neither, so a PAT is required.
+          github-token: ${{ secrets.REPO_STATS_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;


### PR DESCRIPTION
GitHub restricted the stargazer listing endpoints to repository admins and collaborators in July 2026. `GITHUB_TOKEN` acts as `github-actions[bot]`, which is neither, so `listStargazersForRepo` has returned 403 on every scheduled run since 2026-07-13 (last green run was 2026-07-12).

The 403 names `metadata=read` in `x-accepted-github-permissions`, but that scope is granted implicitly and is not settable in a `permissions:` block — the token already has it. The rejection is an identity check, not a scope check, so no `permissions:` change can fix it.

Passes `secrets.REPO_STATS_TOKEN` (fine-grained PAT, `metadata: read` + `issues: read/write`) to `github-script` instead. The PAT needs issue write because the same step both lists stargazers and updates the tracking issue.

The existing `permissions:` block is left in place; it now only governs a token this step no longer uses.

Note: the PAT expires, and when it does these runs fail silently on a schedule — worth adding failure notification separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UV63qKfQYNXDSjSi5WGSwY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository statistics automation to use dedicated authentication.
  * Added documentation clarifying access requirements for retrieving stargazer data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->